### PR TITLE
refactor(writings): redesign home writings section and article card

### DIFF
--- a/app/components/blog/article-card.tsx
+++ b/app/components/blog/article-card.tsx
@@ -38,7 +38,7 @@ function ArticleCard({
         <BlurrableImage
           key={bannerCloudinaryId}
           blurDataUrl={bannerBlurDataUrl}
-          className="aspect-3/4 rounded-lg"
+          className="aspect-3/4 overflow-hidden rounded-lg"
           img={
             <img
               title={title}
@@ -61,7 +61,7 @@ function ArticleCard({
                   },
                 },
               )}
-              className="focus-ring w-full rounded-lg object-cover object-center transition"
+              className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out motion-safe:group-hover:scale-105"
               loading="lazy"
             />
           }

--- a/app/components/blog/article-card.tsx
+++ b/app/components/blog/article-card.tsx
@@ -1,11 +1,11 @@
+import { BlurrableImage } from "@/components/blurrable-image";
+import { AnchorOrLink } from "@/components/links/anchor-or-link";
+import { H4, Text } from "@/components/typography";
+import { ClipboardCopyButton } from "@/components/ui/clipboard-copy-button";
 import { type BlogFrontmatter, type InjectedMeta } from "@/types";
 import { getImageBuilder, getImgProps } from "@/utils/images";
 
-import { BlurrableImage } from "../blurrable-image";
-import { H4, Text } from "../typography";
-
 import { format } from "date-fns";
-import { Link } from "react-router";
 
 type ArticleCardProps = {
   post: BlogFrontmatter & InjectedMeta;
@@ -30,10 +30,10 @@ function ArticleCard({
 
   return (
     <div className="relative w-full" onClick={onClick}>
-      <Link
+      <AnchorOrLink
         prefetch="intent"
         className="group peer relative block w-full focus:outline-none"
-        to={`/writing/${slug}`}
+        href={`/writing/${slug}`}
       >
         <BlurrableImage
           key={bannerCloudinaryId}
@@ -73,7 +73,12 @@ function ArticleCard({
             .join(" — ")}
         </Text>
         <H4 className="mt-2">{title}</H4>
-      </Link>
+      </AnchorOrLink>
+
+      <ClipboardCopyButton
+        value={slug}
+        className="absolute top-6 left-6 z-10"
+      />
     </div>
   );
 }

--- a/app/components/blog/article-card.tsx
+++ b/app/components/blog/article-card.tsx
@@ -2,7 +2,7 @@ import { type BlogFrontmatter, type InjectedMeta } from "@/types";
 import { getImageBuilder, getImgProps } from "@/utils/images";
 
 import { BlurrableImage } from "../blurrable-image";
-import { H4 } from "../typography";
+import { H4, Text } from "../typography";
 
 import { format } from "date-fns";
 import { Link } from "react-router";
@@ -38,7 +38,7 @@ function ArticleCard({
         <BlurrableImage
           key={bannerCloudinaryId}
           blurDataUrl={bannerBlurDataUrl}
-          className="aspect-[3/4] rounded-lg"
+          className="aspect-3/4 rounded-lg"
           img={
             <img
               title={title}
@@ -67,14 +67,12 @@ function ArticleCard({
           }
         />
 
-        <H4 className="text-body-dark mt-8">
+        <Text as="p" variant="overline" className="mt-8">
           {[dateDisplay, readingTime?.text ?? "quick read"]
             .filter(Boolean)
             .join(" — ")}
-        </H4>
-        <H4 as="div" variant="secondary" className="mt-2">
-          {title}
-        </H4>
+        </Text>
+        <H4 className="mt-2">{title}</H4>
       </Link>
     </div>
   );

--- a/app/components/blurrable-image.tsx
+++ b/app/components/blurrable-image.tsx
@@ -70,19 +70,24 @@ function BlurrableImage({
   });
 
   return (
-    <div {...rest}>
+    <div {...rest} className={clsxm(rest.className, "relative")}>
+      {jsImgEl}
       {blurDataUrl ? (
-        <>
+        <div
+          className={clsxm(
+            "pointer-events-none absolute inset-0 transition-opacity",
+            { "opacity-0": visible },
+          )}
+        >
           <img
             key={blurDataUrl}
             src={blurDataUrl}
-            className={img.props.className}
+            className="h-full w-full rounded-lg object-cover object-center"
             alt={img.props.alt}
           />
-          <div className={clsxm(img.props.className, "backdrop-blur-xl")} />
-        </>
+          <div className="absolute inset-0 rounded-lg backdrop-blur-xl" />
+        </div>
       ) : null}
-      {jsImgEl}
       <noscript>{img}</noscript>
     </div>
   );

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -24,7 +24,7 @@ const contacts = [
 
 export function Footer() {
   return (
-    <Grid as="footer" className="bottom-18 gap-8 md:bottom-0">
+    <Grid as="footer" className="gap-8">
       <div className="col-span-full mx-auto flex flex-col items-center gap-y-4 md:pb-12">
         <Logo className="w-8" />
         <div className="flex items-center space-x-4">

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,10 +1,10 @@
 import { clsxm } from "@/utils/clsxm";
 
+import { ButtonLink } from "./ui/button";
 import { Grid } from "./grid";
-import { H2, H3, H4 } from "./typography";
+import { H2, Text } from "./typography";
 
 import { ArrowRightCircleIcon } from "@heroicons/react/24/outline";
-import { Link } from "react-router";
 
 interface HeaderProps {
   title: string;
@@ -37,15 +37,18 @@ function Header({
         )}
       >
         <div className="flex flex-col space-y-2 self-stretch">
-          <H4>{subTitle}</H4>
-          <H2 variant="secondary">{title}</H2>
+          <H2 variant="primary">{title}</H2>
+          <Text variant="lead">{subTitle}</Text>
         </div>
 
         {cta && ctaUrl ? (
-          <Link className="group flex items-center space-x-6" to={ctaUrl}>
-            <H3>{cta}</H3>
-            <ArrowRightCircleIcon className="dark:text-light h-8 w-8 text-black duration-500 group-hover:translate-x-1.5" />
-          </Link>
+          <ButtonLink
+            variant="ghost"
+            href={ctaUrl}
+            iconRight={<ArrowRightCircleIcon />}
+          >
+            {cta}
+          </ButtonLink>
         ) : null}
       </div>
     </Grid>

--- a/app/components/home/blog-section.tsx
+++ b/app/components/home/blog-section.tsx
@@ -19,8 +19,8 @@ export function BlogSection({ title, subTitle, cta, posts }: BlogSectionProps) {
   return (
     <>
       <Header title={title} subTitle={subTitle} cta={cta} ctaUrl="/writing" />
-      <Spacer size="2xs" />
-      <Grid className="gap-10">
+      <Spacer size="lg" />
+      <Grid className="gap-6">
         {posts.map((post, idx) => (
           <div
             key={post.slug}

--- a/app/components/layout/layout-root.tsx
+++ b/app/components/layout/layout-root.tsx
@@ -4,7 +4,7 @@ type LayoutRootProps = {
 
 function LayoutRoot({ children }: LayoutRootProps) {
   return (
-    <div className="bg-light dark:bg-dark relative flex min-h-screen flex-col">
+    <div className="bg-light dark:bg-dark relative flex min-h-screen flex-col pb-24 md:pb-0">
       {children}
     </div>
   );

--- a/app/components/spacer.tsx
+++ b/app/components/spacer.tsx
@@ -1,10 +1,7 @@
 const spacerSizes = {
-  "3xs": "h-6 lg:h-8",
-  "2xs": "h-10 lg:h-12",
-  xs: "h-20 lg:h-24",
-  sm: "h-32 lg:h-36",
-  base: "h-40 lg:h-48",
-  lg: "h-56 lg:h-64",
+  sm: "h-6 lg:h-8",
+  md: "h-10 lg:h-12",
+  lg: "h-16 lg:h-20",
 };
 
 function Spacer({

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -85,9 +85,9 @@ function Button({
     <button
       {...buttonProps}
       className={clsxm(
-        getBaseClassName({ className }),
         getVariantClassName(variant),
         getSizeClassName(size),
+        getBaseClassName({ className }),
       )}
     >
       <ButtonInner iconLeft={iconLeft} iconRight={iconRight}>

--- a/app/components/ui/clipboard-copy-button.tsx
+++ b/app/components/ui/clipboard-copy-button.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+import { clsxm } from "@/utils/clsxm.ts";
+
+import { Button } from "./button";
+
+import { DocumentDuplicateIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
+async function copyToClipboard(value: string) {
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+enum State {
+  Idle = "idle",
+  Copy = "copy",
+  Copied = "copied",
+}
+
+export function ClipboardCopyButton({
+  value,
+  className,
+}: {
+  value: string;
+  className?: string;
+}) {
+  const [state, setState] = useState<State>(State.Idle);
+
+  useEffect(() => {
+    async function transition() {
+      switch (state) {
+        case State.Copy: {
+          const res = await copyToClipboard(value);
+          console.info("copied", res);
+          setState(State.Copied);
+          break;
+        }
+        case State.Copied: {
+          setTimeout(() => {
+            setState(State.Idle);
+          }, 2000);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    void transition();
+  }, [state, value]);
+
+  const copied = state === State.Copied;
+
+  return (
+    <Button
+      variant="secondary"
+      onClick={() => setState(State.Copy)}
+      className={clsxm(
+        "p-4 whitespace-nowrap shadow transition group-hover:opacity-100 peer-hover:opacity-100 peer-focus:opacity-100 hover:opacity-100 hover:shadow-md focus:opacity-100 focus:outline-none active:scale-[0.97] lg:opacity-0",
+        className,
+      )}
+    >
+      <span className="relative inline-flex size-6 shrink-0">
+        <span
+          className={clsxm(
+            "absolute inset-0 transition-all duration-200",
+            copied ? "opacity-0 blur-sm" : "opacity-100 blur-none",
+          )}
+        >
+          <DocumentDuplicateIcon />
+        </span>
+        <span
+          className={clsxm(
+            "absolute inset-0 transition-all duration-200",
+            copied ? "opacity-100 blur-none" : "opacity-0 blur-sm",
+          )}
+        >
+          <CheckCircleIcon />
+        </span>
+      </span>
+    </Button>
+  );
+}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -48,18 +48,14 @@ export default function IndexRoute({ loaderData }: Route.ComponentProps) {
   return (
     <React.Fragment>
       <HeroSection />
-      <AboutSection />
-      <Spacer size="lg" />
-      <ServicesSection />
+
       <Spacer size="lg" />
       <BlogSection
-        title="Find the latest of my writing here"
-        subTitle="blog"
-        cta="See the full blog"
+        title="Recent Writing"
+        subTitle="Find the latest of my writing here."
+        cta="See more posts"
         posts={featuredPosts}
       />
-      <Spacer size="lg" />
-      <CtaSection />
       <Spacer size="lg" />
     </React.Fragment>
   );


### PR DESCRIPTION
## Summary

- Redesign home page to focus on Hero + Recent Writing sections (remove About, Services, CTA sections)
- Fix `BlurrableImage` so blur overlay sits on top and crossfades out when the real image loads
- Fix footer mobile layout: remove `bottom-18` visual hack, use `pb-24` on `LayoutRoot` to properly clear the floating navbar
- Add `ClipboardCopyButton` on article card with blur crossfade animation between copy/check icons
- Add image scale-up animation on article card hover (`group-hover:scale-105`) with `overflow-hidden` clipping and `motion-safe:` reduced motion support
- Consolidate `Spacer` sizes to `sm/md/lg` scale
- Refactor `Header` to use `H2 + ButtonLink` with ghost variant for CTA

## Test plan

- [ ] Home page renders Hero + Recent Writing sections correctly
- [ ] Article card image blur placeholder fades out when real image loads
- [ ] Article card image scales up on hover and stays clipped within rounded corners
- [ ] Clipboard copy button crossfades between copy and check icons on click
- [ ] Footer appears above floating navbar on mobile (no overlap)
- [ ] Footer layout is correct on desktop
- [ ] Reduced motion: no scale/transition animations when `prefers-reduced-motion: reduce` is set