### PR TITLE
fix: make content-refresh CI job resilient and correct build-info path

### DIFF
--- a/other/refresh-changed-content.cjs
+++ b/other/refresh-changed-content.cjs
@@ -3,26 +3,37 @@ const { fetchJson, getChangedFiles, postRefreshCache } = require('./utils.cjs')
 
 const [currentCommitSha] = process.argv.slice(2)
 
+// dep-free fetch that never throws — returns null on any failure (404 HTML,
+// timeout, bad JSON) so a missing endpoint degrades gracefully instead of
+// crashing the whole job.
+async function safeFetchJson(url) {
+	try {
+		return await fetchJson(url, { timeoutTime: 10_000 })
+	} catch (error) {
+		console.log(`Could not read ${url}:`, error?.message ?? error)
+		return null
+	}
+}
+
 async function go() {
-	const shaInfo = await fetchJson(
+	const shaInfo = await safeFetchJson(
 		'https://hanihusam-com.fly.dev/refresh-commit-sha.json',
-		{
-			timeoutTime: 10_000,
-		},
 	)
 	let compareSha = shaInfo?.sha
 	if (!compareSha) {
-		const buildInfo = await fetchJson(
-			'https://hanihusam-com.fly.dev/build/client/build/info.json',
-			{
-				timeoutTime: 10_000,
-			},
+		// Static build info is served from the build/client root, so it lives at
+		// /build/info.json (not /build/client/build/info.json). Shape is
+		// { buildTime, commit: { sha, ... } }.
+		const buildInfo = await safeFetchJson(
+			'https://hanihusam-com.fly.dev/build/info.json',
 		)
-		compareSha = buildInfo.data.sha
-		console.log(`No compare sha found, using build sha: ${buildInfo.data.sha}`)
+		compareSha = buildInfo?.commit?.sha
+		if (compareSha) {
+			console.log(`No compare sha found, using build sha: ${compareSha}`)
+		}
 	}
 	if (typeof compareSha !== 'string') {
-		console.log('🤷‍♂️ No sha to compare to. Unsure what to refresh.')
+		console.log('🤷‍♂️ No sha to compare to. Nothing to refresh.')
 		return
 	}
 

--- a/other/utils.cjs
+++ b/other/utils.cjs
@@ -2,7 +2,7 @@
 const { execSync } = require('child_process')
 const https = require('https')
 
-function fetchJson(url, { timoutTime } = {}) {
+function fetchJson(url, { timeoutTime } = {}) {
 	return new Promise((resolve, reject) => {
 		const request = https
 			.get(url, (res) => {
@@ -22,10 +22,10 @@ function fetchJson(url, { timoutTime } = {}) {
 			.on('error', (e) => {
 				reject(e)
 			})
-		if (timoutTime) {
+		if (timeoutTime) {
 			setTimeout(() => {
 				request.destroy(new Error('Request timed out'))
-			}, timoutTime)
+			}, timeoutTime)
 		}
 	})
 }


### PR DESCRIPTION
The 🥬 **Refresh Content** workflow has been failing on every push to main (pre-existing, unrelated to the LiteFS work — just surfaced while verifying CI/CD).

## Root cause
`other/refresh-changed-content.cjs` fetched the build info from `/build/client/build/info.json`, but the file is served from the `build/client` static root at **`/build/info.json`**. That 404'd, returned an HTML error page, and an unhandled `JSON.parse` on the `<` crashed the job. It also read `buildInfo.data.sha` while the actual shape is `{ commit: { sha } }`.

## Fix
- Point the fallback at `/build/info.json` and read `commit.sha`
- Wrap fetches in `safeFetchJson` (returns `null` instead of throwing) so a missing endpoint degrades to "nothing to refresh" rather than failing CI
- Fix the `timoutTime` typo in `fetchJson` so the 10s timeout actually applies

Validated locally against production: falls back to the build sha and exits 0.