### PR TITLE
feat: add top progressive-blur overlay that fades in on scroll

### DIFF
--- a/app/components/top-blur-overlay.tsx
+++ b/app/components/top-blur-overlay.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { clsxm } from "@/utils/clsxm";
+
+/**
+ * Fixed progressive-blur overlay pinned to the top of the viewport.
+ * Content scrolling underneath ramps from sharp to blurred toward the top
+ * edge. The overlay fades in once the page is scrolled away from the top.
+ */
+export function TopBlurOverlay() {
+  const [scrolled, setScrolled] = React.useState(false);
+
+  React.useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 16);
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div
+      aria-hidden
+      className={clsxm(
+        "top-blur pointer-events-none fixed inset-x-0 top-0 z-30 h-24 transition-opacity duration-300",
+        scrolled ? "opacity-100" : "opacity-0",
+      )}
+    >
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+    </div>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,6 +14,7 @@ import { getTheme } from "@/utils/theme.server";
 
 import { type Route } from "./+types/root";
 import { Navigation } from "./components/navigation";
+import { TopBlurOverlay } from "./components/top-blur-overlay";
 
 import {
   isRouteErrorResponse,
@@ -169,6 +170,7 @@ function App({
       </head>
       <body>
         <LayoutRoot surface={surface}>
+          <TopBlurOverlay />
           <Outlet />
           <Footer />
           <Navigation />

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -81,3 +81,57 @@ light-mode {
     transition: none;
   }
 }
+
+/*
+ * Progressive blur overlay (top of viewport).
+ * Stacked layers each apply a stronger backdrop blur, masked to an
+ * overlapping band so the blur ramps up smoothly toward the top edge
+ * (clear at the bottom, fully blurred at the top) as content scrolls under.
+ */
+.top-blur > div {
+  position: absolute;
+  inset: 0;
+}
+.top-blur > div:nth-child(1) {
+  backdrop-filter: blur(1px);
+  -webkit-backdrop-filter: blur(1px);
+  mask: linear-gradient(to top, #000 0%, #000 12.5%, transparent 25%);
+}
+.top-blur > div:nth-child(2) {
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  mask: linear-gradient(
+    to top,
+    transparent 12.5%,
+    #000 25%,
+    #000 37.5%,
+    transparent 50%
+  );
+}
+.top-blur > div:nth-child(3) {
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  mask: linear-gradient(
+    to top,
+    transparent 37.5%,
+    #000 50%,
+    #000 62.5%,
+    transparent 75%
+  );
+}
+.top-blur > div:nth-child(4) {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  mask: linear-gradient(
+    to top,
+    transparent 62.5%,
+    #000 75%,
+    #000 87.5%,
+    transparent 100%
+  );
+}
+.top-blur > div:nth-child(5) {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  mask: linear-gradient(to top, transparent 87.5%, #000 100%);
+}


### PR DESCRIPTION
## Summary

Adds a fixed, full-width **progressive-blur overlay** pinned to the top of the viewport — content scrolling underneath ramps from sharp (bottom edge) to fully blurred (top edge). The overlay is hidden at the top of the page and **fades in once you scroll** past ~16px.

Sized and placed from the Figma "Top Blur Container" design (96px tall band). Implemented as a true live CSS progressive blur (5 stacked `backdrop-filter` layers with overlapping mask gradients), since Figma can only bake the effect into a static image.

### Changes
- `app/components/top-blur-overlay.tsx` — new client component; fades in (`opacity` 0→1, 300ms) once `scrollY > 16`. `aria-hidden`, `pointer-events-none`, `z-30`, `h-24`.
- `app/styles/app.css` — `.top-blur` progressive-blur layers (blur 1→2→4→8→16px), `-webkit-` prefixed.
- `app/root.tsx` — mounts `<TopBlurOverlay />` in `LayoutRoot`.

### Verification
- Typecheck/lint clean on changed files.
- Verified live in the browser: hidden at top (`opacity: 0`), fades in on scroll, heading blurs at the top edge while content below stays sharp.

> Note: this branch also includes the LiteFS-removal commits (merged from `chore/remove-litefs`, which isn't on `origin`), so the diff against `main` shows those changes too. If `chore/remove-litefs` is merged first, only the 3 files above remain as the net diff.