### PR TITLE
fix: replace leftover heroicons imports with phosphor-icons

### DIFF
--- a/app/components/mdx/code-block.tsx
+++ b/app/components/mdx/code-block.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { clsxm } from "@/utils/clsxm";
 
-import { CheckIcon, ClipboardIcon } from "@heroicons/react/24/outline";
+import { CheckIcon, ClipboardIcon } from "@phosphor-icons/react";
 
 type CodeBlockProps = React.ComponentPropsWithoutRef<"pre"> & {
   "data-language"?: string;

--- a/app/components/works/toc-drawer.tsx
+++ b/app/components/works/toc-drawer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { type HeadingScrollSpy, TocList } from "@/components/works/toc-list";
 
-import { ListBulletIcon } from "@heroicons/react/24/outline";
+import { ListBulletsIcon } from "@phosphor-icons/react";
 import { Drawer } from "vaul";
 
 type WorkTocDrawerProps = {
@@ -31,7 +31,7 @@ export function WorkTocDrawer({
         aria-label="Open table of contents"
         className="fixed right-8 bottom-8 z-20 grid size-11 place-items-center rounded-md border border-(--border-primary) bg-(--surface-primary) text-(--icon-primary) shadow-lg transition-colors hover:bg-(--nav-item-surface-active) focus:outline-none lg:hidden"
       >
-        <ListBulletIcon className="h-5 w-5" />
+        <ListBulletsIcon className="h-5 w-5" />
       </Drawer.Trigger>
 
       <Drawer.Portal>

--- a/app/routes/works.$slug.tsx
+++ b/app/routes/works.$slug.tsx
@@ -23,13 +23,11 @@ import { getServerTimeHeader } from "@/utils/timing.server";
 import { type Route } from "./+types/works.$slug";
 
 import {
-  ArrowCircleLeftIcon,
+  ArrowLeftIcon,
   ArrowSquareOutIcon,
   CodeIcon,
-  ThumbsUpIcon,
 } from "@phosphor-icons/react";
-import { motion } from "framer-motion";
-import { data, Link, useFetcher } from "react-router";
+import { data, useFetcher } from "react-router";
 
 export async function action({ params, request }: Route.ActionArgs) {
   if (!params.slug) {
@@ -240,7 +238,7 @@ export default function WorksSlug({ loaderData }: Route.ComponentProps) {
               to="/works"
               variant="ghost"
               size="md"
-              iconLeft={<ArrowSmallLeftIcon />}
+              iconLeft={<ArrowLeftIcon />}
             >
               Back to the list
             </ButtonLink>
@@ -287,7 +285,7 @@ export default function WorksSlug({ loaderData }: Route.ComponentProps) {
                         rel="noopener noreferrer"
                         className="flex items-center gap-1.5 text-base text-(--text-paragraph) transition-colors hover:text-(--text-link)"
                       >
-                        <CodeBracketIcon className="size-5" />
+                        <CodeIcon className="size-5" />
                         Repository
                       </a>
                     ) : null}
@@ -298,7 +296,7 @@ export default function WorksSlug({ loaderData }: Route.ComponentProps) {
                         rel="noopener noreferrer"
                         className="flex items-center gap-1.5 text-base text-(--text-paragraph) transition-colors hover:text-(--text-link)"
                       >
-                        <ArrowTopRightOnSquareIcon className="size-5" />
+                        <ArrowSquareOutIcon className="size-5" />
                         Open Live Site
                       </a>
                     ) : null}


### PR DESCRIPTION
## Problem
The work-detail redesign (#137) merged at the same time as the heroicons → phosphor migration (#136). The merge left the build broken on `main`:

- **`works.$slug.tsx`** imported phosphor names (`ArrowCircleLeftIcon`, `ThumbsUpIcon`, …) but the JSX still referenced **undefined** heroicons identifiers (`ArrowSmallLeftIcon`, `CodeBracketIcon`, `ArrowTopRightOnSquareIcon`), plus dead `motion`/`Link` imports.
- **`code-block.tsx`** and **`toc-drawer.tsx`** still imported from `@heroicons/react`, which the migration removed from dependencies.

## Fix
- `works.$slug.tsx`: `ArrowSmallLeftIcon → ArrowLeftIcon`, `CodeBracketIcon → CodeIcon`, `ArrowTopRightOnSquareIcon → ArrowSquareOutIcon`; remove unused `motion` and `Link`.
- `code-block.tsx`: `CheckIcon`, `ClipboardIcon` from `@phosphor-icons/react`.
- `toc-drawer.tsx`: `ListBulletIcon → ListBulletsIcon` from `@phosphor-icons/react`.

## Verification
`npm run build` ✅ and `npm run typecheck` ✅ both pass locally.