### PR TITLE
chore: migrate lint/format to oxlint + oxfmt

### DIFF
--- a/app/components/top-blur-overlay.tsx
+++ b/app/components/top-blur-overlay.tsx
@@ -22,7 +22,7 @@ export function TopBlurOverlay() {
 		<div
 			aria-hidden
 			className={clsxm(
-				'top-blur pointer-events-none fixed inset-x-0 top-0 z-30 h-24 transition-opacity duration-300',
+				'top-blur pointer-events-none fixed inset-x-0 top-0 z-30 h-16 transition-opacity duration-300 sm:h-24',
 				scrolled ? 'opacity-100' : 'opacity-0',
 			)}
 		>

--- a/app/components/works/cta-section.tsx
+++ b/app/components/works/cta-section.tsx
@@ -16,7 +16,7 @@ export function CallToAction() {
 				color="sky"
 				rows={5}
 				cols={5}
-				className="absolute bottom-2 left-[14%] hidden lg:block"
+				className="absolute bottom-2 left-[8%] md:left-[14%]"
 			/>
 
 			<div className="col-span-full flex flex-col items-center gap-8 text-center">

--- a/app/routes/works.$slug.tsx
+++ b/app/routes/works.$slug.tsx
@@ -216,7 +216,7 @@ export default function WorksSlug({ loaderData }: Route.ComponentProps) {
 				color="sunset"
 				rows={8}
 				cols={8}
-				className="pointer-events-none absolute top-12 right-[6%] hidden md:block"
+				className="pointer-events-none absolute top-12 -right-4 md:right-[6%]"
 			/>
 			<ConcentricCircles
 				accent


### PR DESCRIPTION
## Summary

Migrates the project's lint/format tooling to **oxlint + oxfmt** and bundles several UI/content fixes made along the way.

## Changes

- **chore:** migrate lint/format to oxlint + oxfmt (replaces previous tooling, adds pre-commit lint-staged hook)
- **feat:** replace hardcoded SVGs with `@icons-pack/react-simple-icons`
- **feat:** add a 404 not found page
- **fix:** resolve SonarCloud code analysis findings
- **style:** shorten top blur overlay on small viewports and refine works layout decorative positioning

## Notes

- Most of the diff is automated reformatting from the new oxfmt config.
- The blur overlay now uses `h-16` on mobile and `h-24` from the `sm` breakpoint up.
