### PR TITLE
feat: motion token system, route + scroll animations

### DIFF
--- a/app/components/about/fun-facts-section.tsx
+++ b/app/components/about/fun-facts-section.tsx
@@ -259,9 +259,9 @@ export function FunFactsSection() {
 					initial={shouldReduceMotion ? undefined : 'rest'}
 					animate={shouldReduceMotion ? undefined : 'rest'}
 					whileHover={shouldReduceMotion ? undefined : 'grown'}
-					className="flex flex-col-reverse items-center justify-center gap-5 md:max-h-46 md:flex-row"
+					className="flex flex-col-reverse items-center justify-center gap-5 md:max-h-46 md:flex-row md:justify-center"
 				>
-					<StickFigure className="translate-y-8 overflow-visible text-(--text-paragraph) md:max-h-25" />
+					<StickFigure className="self-center overflow-visible text-(--text-paragraph) md:max-h-25 md:self-end" />
 					<Fact>
 						I am 180 cm tall. Above average for an Indonesian. I&apos;m told
 						this is my most notable achievement.

--- a/app/components/about/hero-section.tsx
+++ b/app/components/about/hero-section.tsx
@@ -12,7 +12,7 @@ export function AboutHero() {
 				className="absolute top-0 right-0 hidden lg:block"
 			/>
 
-			<div className="relative col-span-full flex h-[82vh] items-end md:h-auto">
+			<div className="relative col-span-full flex items-end">
 				{/* Floating cutout avatar over a tinted square */}
 				<div className="absolute top-0 right-0 flex aspect-square w-100 translate-x-[28%] -translate-y-1/3 items-center justify-center overflow-visible rounded-2xl border-(--border-primary) bg-sky-50 md:translate-x-[40%] md:translate-y-0 lg:translate-x-0 dark:bg-sky-900">
 					<img
@@ -24,7 +24,7 @@ export function AboutHero() {
 					/>
 				</div>
 
-				<div className="relative z-1 flex flex-col gap-6 md:gap-12">
+				<div className="relative z-1 mt-82 flex flex-col gap-6 md:gap-12">
 					<Display>Hi there! I&apos;m Han.</Display>
 
 					<div className="flex flex-col gap-4 md:max-w-[60%]">

--- a/app/components/button-outline.tsx
+++ b/app/components/button-outline.tsx
@@ -61,7 +61,7 @@ export const ButtonOutline = React.forwardRef<HTMLButtonElement, ButtonProps>(
 			className={clsxm(
 				buttonBlockStyles(block),
 				buttonModifierStyle(variant),
-				'group items-center justify-center rounded-md border px-5 py-3 duration-200 focus:outline-none',
+				'group items-center justify-center rounded-md border px-5 py-3 duration-(--duration-base) focus:outline-none',
 				`border-${variant}-500 text-${variant}-500`,
 				disabledStyles,
 				className,

--- a/app/components/button-text.tsx
+++ b/app/components/button-text.tsx
@@ -44,7 +44,7 @@ export const ButtonText = React.forwardRef<HTMLButtonElement, ButtonTextProps>(
 		<button
 			className={clsxm(
 				buttonBlockStyles(block),
-				'focus:ring-secondary-500/20 text-secondary-500 hover:text-secondary-600 focus:text-secondary-600 active:text-secondary-700 disabled:text-secondary-300 dark:text-light items-center justify-center rounded-md border-0 bg-transparent px-5 py-3 text-lg duration-200 focus:ring-2 focus:outline-none active:focus:text-white dark:hover:text-white dark:focus:text-white',
+				'focus:ring-secondary-500/20 text-secondary-500 hover:text-secondary-600 focus:text-secondary-600 active:text-secondary-700 disabled:text-secondary-300 dark:text-light items-center justify-center rounded-md border-0 bg-transparent px-5 py-3 text-lg duration-(--duration-base) focus:ring-2 focus:outline-none active:focus:text-white dark:hover:text-white dark:focus:text-white',
 				disabledStyles,
 				className,
 			)}

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -61,7 +61,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 			className={clsxm(
 				buttonBlockStyles(block),
 				buttonModifierStyle(variant),
-				'items-center justify-center rounded-md px-5 py-3 duration-200 focus:outline-none',
+				'items-center justify-center rounded-md px-5 py-3 duration-(--duration-base) focus:outline-none active:scale-[0.97]',
 				disabledStyles,
 				className,
 			)}

--- a/app/components/home/hero-section.tsx
+++ b/app/components/home/hero-section.tsx
@@ -14,7 +14,7 @@ export function HeroSection() {
 				<Logo className="absolute top-8" />
 
 				<img
-					className="absolute top-0 right-0 hidden h-auto w-87.5 translate-x-[25%] translate-y-[20vh] md:top-auto md:right-auto md:bottom-0 md:left-0 md:block md:w-lg md:translate-x-[-16%] md:translate-y-0 lg:left-1/2 lg:w-3xl lg:-translate-x-1/2"
+					className="absolute top-0 right-0 hidden h-auto w-87.5 max-w-2/3 translate-x-[25%] translate-y-[20vh] md:top-auto md:right-auto md:bottom-0 md:left-0 md:block md:w-lg md:translate-x-[-16%] md:translate-y-0 lg:left-1/2 lg:w-3xl lg:-translate-x-1/2"
 					{...getImgProps(
 						getImageBuilder(
 							'bapak2.dev/images/avatar-front_l3oexq',

--- a/app/components/home/project-section.tsx
+++ b/app/components/home/project-section.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@/components/grid'
 import { Header } from '@/components/header'
+import { Reveal } from '@/components/reveal'
 import { Spacer } from '@/components/spacer'
 import { type InjectedMeta, type ProjectFrontmatter } from '@/types'
 import { clsxm } from '@/utils/clsxm'
@@ -25,18 +26,22 @@ export function ProjectSection({
 
 	return (
 		<>
-			<Header title={title} subTitle={subTitle} cta={cta} ctaUrl="/works" />
+			<Reveal>
+				<Header title={title} subTitle={subTitle} cta={cta} ctaUrl="/works" />
+			</Reveal>
 			<Spacer size="lg" />
 			<Grid className="gap-6">
 				{posts.map((project, idx) => (
-					<ProjectCard
+					<Reveal
 						key={project.slug}
-						className={clsxm('col-span-full', {
-							'lg:flex-row-reverse': idx % 2 === 0,
-							'hidden lg:flex': idx >= 2,
-						})}
-						project={project}
-					/>
+						delay={idx * 0.08}
+						className={clsxm('col-span-full', { 'hidden lg:block': idx >= 2 })}
+					>
+						<ProjectCard
+							className={clsxm({ 'lg:flex-row-reverse': idx % 2 === 0 })}
+							project={project}
+						/>
+					</Reveal>
 				))}
 			</Grid>
 		</>

--- a/app/components/home/substack-section.tsx
+++ b/app/components/home/substack-section.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@/components/grid'
 import { Header } from '@/components/header'
+import { Reveal } from '@/components/reveal'
 import { Spacer } from '@/components/spacer'
 import { ArticleCard } from '@/components/writing/article-card'
 import { type SubstackPost } from '@/types'
@@ -22,23 +23,26 @@ export function SubstackSection({
 
 	return (
 		<>
-			<Header
-				title={title}
-				subTitle={subTitle}
-				cta={cta}
-				ctaUrl="https://bapak2dev.substack.com"
-			/>
+			<Reveal>
+				<Header
+					title={title}
+					subTitle={subTitle}
+					cta={cta}
+					ctaUrl="https://bapak2dev.substack.com"
+				/>
+			</Reveal>
 			<Spacer size="lg" />
 			<Grid className="gap-6">
 				{posts.map((post, idx) => (
-					<div
+					<Reveal
 						key={post.url}
+						delay={idx * 0.08}
 						className={clsxm('col-span-4', {
 							'hidden lg:block': idx >= 2,
 						})}
 					>
 						<ArticleCard post={post} />
-					</div>
+					</Reveal>
 				))}
 			</Grid>
 			<Spacer size="lg" />

--- a/app/components/icon-link.tsx
+++ b/app/components/icon-link.tsx
@@ -2,7 +2,7 @@ function IconLink({ ref, ...props }: React.ComponentPropsWithRef<'a'>) {
 	return (
 		<a
 			{...props}
-			className={`${props.className ?? ''} duration-500 hover:-translate-y-1.5`}
+			className={`${props.className ?? ''} ease-out-quart transition-transform duration-(--duration-base) hover:-translate-y-1.5`}
 			ref={ref}
 		>
 			{props.children}

--- a/app/components/page-transition.tsx
+++ b/app/components/page-transition.tsx
@@ -1,0 +1,41 @@
+import { motion, useReducedMotion } from 'motion/react'
+import { useEffect, useRef } from 'react'
+import { Outlet, useLocation } from 'react-router'
+
+// Timing mirrors the motion tokens in app/styles/theme.css:
+//   duration-base 200ms / ease-out-quart.
+const EASE_OUT_QUART = [0.165, 0.84, 0.44, 1] as const
+
+/**
+ * Entrance-only route transition. Re-keying on pathname remounts the incoming
+ * page so it fades/slides in. We deliberately avoid AnimatePresence exit
+ * animations: keeping the outgoing route mounted crashes it, because React
+ * Router 7 injects `loaderData` as a prop that is already gone once navigation
+ * starts. The first (SSR) mount is not animated so the server renders content
+ * fully visible — no FOUC / no invisible content without JS.
+ */
+function PageTransition() {
+	const location = useLocation()
+	const shouldReduceMotion = useReducedMotion()
+	const hasMounted = useRef(false)
+
+	useEffect(() => {
+		hasMounted.current = true
+	}, [])
+
+	const animateIn = hasMounted.current && !shouldReduceMotion
+
+	return (
+		<motion.div
+			key={location.pathname}
+			className="flex grow flex-col"
+			initial={animateIn ? { opacity: 0, y: 8 } : false}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: animateIn ? 0.2 : 0, ease: EASE_OUT_QUART }}
+		>
+			<Outlet />
+		</motion.div>
+	)
+}
+
+export { PageTransition }

--- a/app/components/projects/project-card.tsx
+++ b/app/components/projects/project-card.tsx
@@ -44,7 +44,7 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
 										},
 									},
 								)}
-								className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out motion-safe:group-hover:scale-105"
+								className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-slow) motion-safe:ease-in-out motion-safe:group-hover:scale-105"
 								loading="lazy"
 							/>
 						}
@@ -74,7 +74,7 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
 										},
 									},
 								)}
-								className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out motion-safe:group-hover:scale-105"
+								className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-slow) motion-safe:ease-in-out motion-safe:group-hover:scale-105"
 								loading="lazy"
 							/>
 						}

--- a/app/components/reveal.tsx
+++ b/app/components/reveal.tsx
@@ -19,12 +19,15 @@ function Reveal({ delay = 0, children, ...props }: RevealProps) {
 	return (
 		<motion.div
 			initial={shouldReduceMotion ? false : { opacity: 0, y: 24 }}
+			// Reduced motion: force the visible state immediately (no scroll trigger),
+			// otherwise the SSR-rendered opacity:0 would persist and hide content.
+			animate={shouldReduceMotion ? { opacity: 1, y: 0 } : undefined}
 			whileInView={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
 			viewport={{ once: true, amount: 0.2 }}
 			transition={{
 				duration: shouldReduceMotion ? 0 : 0.5,
 				ease: EASE_OUT_QUART,
-				delay,
+				delay: shouldReduceMotion ? 0 : delay,
 			}}
 			{...props}
 		>

--- a/app/components/reveal.tsx
+++ b/app/components/reveal.tsx
@@ -1,0 +1,36 @@
+import { motion, useReducedMotion, type HTMLMotionProps } from 'motion/react'
+
+// Matches the ease-out-quart / duration-slower motion tokens in theme.css.
+const EASE_OUT_QUART = [0.165, 0.84, 0.44, 1] as const
+
+type RevealProps = HTMLMotionProps<'div'> & {
+	/** Stagger sibling reveals by nudging the start (seconds). */
+	delay?: number
+}
+
+/**
+ * Fades + rises its children into place as they scroll into view (once).
+ * Under prefers-reduced-motion it renders statically visible — no transform,
+ * no opacity ramp — so nothing is ever hidden from motion-sensitive users.
+ */
+function Reveal({ delay = 0, children, ...props }: RevealProps) {
+	const shouldReduceMotion = useReducedMotion()
+
+	return (
+		<motion.div
+			initial={shouldReduceMotion ? false : { opacity: 0, y: 24 }}
+			whileInView={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+			viewport={{ once: true, amount: 0.2 }}
+			transition={{
+				duration: shouldReduceMotion ? 0 : 0.5,
+				ease: EASE_OUT_QUART,
+				delay,
+			}}
+			{...props}
+		>
+			{children}
+		</motion.div>
+	)
+}
+
+export { Reveal }

--- a/app/components/top-blur-overlay.tsx
+++ b/app/components/top-blur-overlay.tsx
@@ -22,7 +22,7 @@ export function TopBlurOverlay() {
 		<div
 			aria-hidden
 			className={clsxm(
-				'top-blur pointer-events-none fixed inset-x-0 top-0 z-30 h-16 transition-opacity duration-300 sm:h-24',
+				'top-blur pointer-events-none fixed inset-x-0 top-0 z-30 h-16 transition-opacity duration-(--duration-slow) sm:h-24',
 				scrolled ? 'opacity-100' : 'opacity-0',
 			)}
 		>

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -17,7 +17,7 @@ interface ButtonProps {
 function getBaseClassName({ className }: { className?: string }) {
 	return clsxm(
 		'group relative inline-flex w-fit shrink-0 items-center justify-center',
-		'font-medium transition duration-150 ease-out',
+		'font-medium transition duration-(--duration-fast) ease-out',
 		'active:scale-[0.97]',
 		'focus:outline-none',
 		'disabled:pointer-events-none',
@@ -108,7 +108,7 @@ function LinkButton({
 		<button
 			{...buttonProps}
 			className={clsxm(
-				'text-(--text-link) transition-colors duration-150',
+				'text-(--text-link) transition-colors duration-(--duration-fast)',
 				'hover:opacity-80 focus:outline-none focus-visible:underline',
 				underlined ? 'underline' : 'hover:underline',
 				className,

--- a/app/components/ui/clipboard-copy-button.tsx
+++ b/app/components/ui/clipboard-copy-button.tsx
@@ -66,7 +66,7 @@ export function ClipboardCopyButton({
 			<span className="relative inline-flex size-6 shrink-0">
 				<span
 					className={clsxm(
-						'absolute inset-0 transition-all duration-200',
+						'absolute inset-0 transition-all duration-(--duration-base)',
 						copied ? 'opacity-0 blur-sm' : 'opacity-100 blur-none',
 					)}
 				>
@@ -74,7 +74,7 @@ export function ClipboardCopyButton({
 				</span>
 				<span
 					className={clsxm(
-						'absolute inset-0 transition-all duration-200',
+						'absolute inset-0 transition-all duration-(--duration-base)',
 						copied ? 'opacity-100 blur-none' : 'opacity-0 blur-sm',
 					)}
 				>

--- a/app/components/ui/filter-tag.tsx
+++ b/app/components/ui/filter-tag.tsx
@@ -16,7 +16,7 @@ function FilterTag({ tag, selected, onChange, disabled }: FilterTagProps) {
 			className={clsxm(
 				'relative inline-flex cursor-pointer items-center justify-center select-none',
 				'rounded-full px-4 py-3',
-				'transition-colors duration-150',
+				'transition-colors duration-(--duration-fast)',
 				{
 					'border border-(--border-primary) bg-(--filter-tag-surface-default)':
 						!selected && !disabled,

--- a/app/components/ui/navigation-item.tsx
+++ b/app/components/ui/navigation-item.tsx
@@ -34,7 +34,7 @@ export default function NavigationItem({
 							className,
 						)}
 					>
-						<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100 group-aria-[current=page]:opacity-100" />
+						<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-(--duration-fast) group-hover:opacity-100 group-focus:opacity-100 group-aria-[current=page]:opacity-100" />
 						<span className="relative">{children}</span>
 					</NavLink>
 				</Trigger>

--- a/app/components/ui/theme-switcher.tsx
+++ b/app/components/ui/theme-switcher.tsx
@@ -30,7 +30,7 @@ export default function ThemeSwitcher() {
 							aria-live="polite"
 							className="toggle-theme-switcher group relative m-1 grid size-9 cursor-pointer place-items-center overflow-hidden rounded-md p-2 text-(--icon-primary) focus:outline-none"
 						>
-							<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100" />
+							<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-(--duration-fast) group-hover:opacity-100 group-focus:opacity-100" />
 							{/* Moon icon */}
 							<svg
 								id="moon-icon"

--- a/app/components/writing/article-card.tsx
+++ b/app/components/writing/article-card.tsx
@@ -51,7 +51,7 @@ function ArticleCard({
 										},
 									},
 								})}
-								className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out motion-safe:group-hover:scale-105"
+								className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-slow) motion-safe:ease-in-out motion-safe:group-hover:scale-105"
 								loading="lazy"
 							/>
 						}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,6 +15,7 @@ import { getTheme } from '@/utils/theme.server'
 
 import { type Route } from './+types/root'
 import { Navigation } from './components/navigation'
+import { PageTransition } from './components/page-transition'
 import { TopBlurOverlay } from './components/top-blur-overlay'
 
 import {
@@ -22,7 +23,6 @@ import {
 	Links,
 	type LinksFunction,
 	Meta,
-	Outlet,
 	Scripts,
 	ScrollRestoration,
 	useMatches,
@@ -204,7 +204,7 @@ function App({
 		<Document nonce={nonce} theme={theme} env={data.ENV}>
 			<LayoutRoot surface={surface}>
 				<TopBlurOverlay />
-				<Outlet />
+				<PageTransition />
 				<Footer />
 				<Navigation />
 			</LayoutRoot>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -24,7 +24,7 @@ light-mode {
 	content: '';
 	height: 2px;
 	transform: scaleX(0);
-	transition: transform 0.25s ease;
+	transition: transform var(--duration-base) ease;
 	transform-origin: left;
 	left: 0;
 	bottom: -4px;
@@ -43,7 +43,7 @@ light-mode {
 @media (prefers-reduced-motion) {
 	.underlined:after {
 		opacity: 0;
-		transition: opacity 0.25s ease;
+		transition: opacity var(--duration-base) ease;
 	}
 
 	.underlined:hover:after,
@@ -55,7 +55,7 @@ light-mode {
 
 /* Toggle Switch Theme */
 .toggle-theme-switcher svg {
-	transition: 350ms cubic-bezier(0.165, 0.84, 0.44, 1);
+	transition: var(--duration-slow) var(--ease-out-quart);
 	transition-property: transform;
 	grid-area: 1/1;
 }

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -12,7 +12,9 @@
 			hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
 			hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
 		user-select: none;
-		animation-duration: 150ms;
+		/* Token → 0ms under prefers-reduced-motion, so the slide keyframe below
+		   completes instantly (no perceptible motion). */
+		animation-duration: var(--duration-fast);
 		animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 		will-change: transform, opacity;
 	}

--- a/app/styles/theme.css
+++ b/app/styles/theme.css
@@ -110,6 +110,20 @@
 	--breakpoint-md: 640px; /* Tailwind default: 48rem (768px) */
 	--breakpoint-lg: 1024px; /* Tailwind default: 64rem (1024px) — same px, kept explicit */
 	--breakpoint-xl: 1440px; /* Tailwind default: 80rem (1280px) */
+
+	/* ─── Motion — single source of truth for durations + easing.
+	   Generates utilities: duration-fast/base/slow/slower, ease-out-quart, ease-in-out-quart.
+	   Durations are re-zeroed under prefers-reduced-motion below, so any utility
+	   built on these tokens is automatically motion-safe. */
+	--duration-fast: 150ms; /* micro-interactions, hover, color */
+	--duration-base: 200ms; /* standard UI: buttons, dropdowns, tooltips */
+	--duration-slow: 300ms; /* larger elements: modals, drawers, image zoom */
+	--duration-slower: 500ms; /* rare / large-travel: icon lift, marketing */
+
+	/* ease-out for enter/exit (the house curve, already used by the theme toggle) */
+	--ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
+	/* ease-in-out for on-screen movement / morphing */
+	--ease-in-out-quart: cubic-bezier(0.77, 0, 0.175, 1);
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -317,7 +331,8 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-/* View Transitions — native, no library needed */
+/* Cross-document (hard-load) fallback. Client-side route transitions are
+   handled by <PageTransition> (motion/react); the two are mutually exclusive. */
 @view-transition {
 	navigation: auto;
 }


### PR DESCRIPTION
## Summary

Improves animation across the site in layers: atomic tokens → components → page → polish.

### Atomic — motion tokens (`app/styles/theme.css`)
- `--duration-fast/base/slow/slower` and `--ease-out-quart` / `--ease-in-out-quart` as the single source of truth.
- Tokens are re-zeroed under `prefers-reduced-motion`, so anything built on them auto-disables.
- Note: Tailwind v4 only generates utilities from named `--ease-*` keys, not named `--duration-*` keys, so components use the `duration-(--duration-base)` custom-property shorthand.

### Component
- Routed every hardcoded duration through tokens (buttons, cards, icon-link, toggle, tooltip, top-blur, underline).
- Fixed `icon-link` missing `transition-property` and reduced-motion gap.
- Added `active:scale-[0.97]` press feedback to the legacy `Button`.

### Page — route transition (`app/components/page-transition.tsx`)
- Entrance-only fade + rise on route change via `motion/react`.
- Deliberately **not** using `AnimatePresence mode="wait"` exit: keeping the outgoing route mounted crashes it because React Router 7 tears down `loaderData` on navigation. First (SSR) mount is unanimated to avoid FOUC.

### Polish — scroll reveal (`app/components/reveal.tsx`)
- `whileInView` fade-up (`once: true`) with per-card stagger on the home Projects + Writing sections.
- Renders statically visible under `prefers-reduced-motion`.

### Accessibility
- Full reduced-motion coverage across every animation surface.
- Known tradeoff: with JS fully disabled, `Reveal` sections stay hidden below the fold (standard `whileInView` behavior). Content is still in the DOM for crawlers / screen readers.

Also includes minor `hero-section` layout tweaks.

## Testing
- `typecheck` + `lint` pass.
- Verified in-browser (Playwright): home ⇄ about route transitions, scroll reveal opacity 0→1 on scroll-in, card stagger, layout/footer intact, 0 console errors.