### PR TITLE
feat: implement SEO suite with signed Cloudinary OG images

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,9 +7,15 @@ import noScriptStyles from '@/styles/no-script.css?url'
 import proseStyles from '@/styles/prose.css?url'
 import tailwindStyles from '@/styles/tailwind.css?url'
 import { ClientHintCheck, getHints } from '@/utils/client-hints'
+import { getSignedSocialImage } from '@/utils/cloudinary.server'
 import { getEnv } from '@/utils/env.server'
-import { toErrorWithMessage } from '@/utils/helpers'
+import {
+	getUrl,
+	removeTrailingSlash,
+	toErrorWithMessage,
+} from '@/utils/helpers'
 import { useNonce } from '@/utils/nonce-provider'
+import { getSocialMetas } from '@/utils/seo'
 import { useTheme } from '@/utils/theme'
 import { getTheme } from '@/utils/theme.server'
 
@@ -25,6 +31,7 @@ import {
 	Meta,
 	Scripts,
 	ScrollRestoration,
+	useLocation,
 	useMatches,
 	useRouteError,
 	useRouteLoaderData,
@@ -100,31 +107,51 @@ export const links: LinksFunction = () => {
 	]
 }
 
-export const meta = () => [
-	{ title: 'Hani Husamuddin' },
-	{
-		property: 'og:title',
-		content: 'Han Personal Website',
-	},
-	{
-		name: 'description',
-		content:
-			'A professional freelancer who could help you solve your software engineer and UI design problem',
-	},
-	{
-		name: 'viewport',
-		content: 'width=device-width,initial-scale=1,viewport-fit=cover',
-	},
-]
+const ROOT_TITLE = 'Hani Husamuddin'
+const ROOT_DESCRIPTION =
+	'A professional freelancer who could help you solve your software engineer and UI design problem'
+
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+	// Default social meta, used as a fallback for any route that does not export
+	// its own `meta`. Note: React Router replaces (not merges) parent meta when a
+	// child route exports `meta`, so tags that must appear on every page
+	// (viewport, theme-color, JSON-LD) live in <Document> instead.
+	return getSocialMetas({
+		url: getUrl(loaderData?.requestInfo),
+		title: ROOT_TITLE,
+		description: ROOT_DESCRIPTION,
+		image: loaderData?.socialImage,
+		keywords:
+			'Hani Husamuddin, Software Engineer, Frontend Engineer, UI Design, Freelancer, React, TypeScript',
+	})
+}
+
+// Person schema rendered on every page (see Document). Kept out of the meta
+// export because child-route meta would replace it.
+const personJsonLd = {
+	'@context': 'https://schema.org',
+	'@type': 'Person',
+	name: 'Hani Husamuddin',
+	url: 'https://hanihusam.com',
+	jobTitle: 'Software Engineer',
+	sameAs: [
+		'https://github.com/hanihusam',
+		'https://www.linkedin.com/in/hanihusam/',
+		'https://bapak2dev.substack.com/',
+	],
+}
 
 export async function loader({ request }: Route.LoaderArgs) {
-	const requestPath = new URL(request.url).pathname
+	const url = new URL(request.url)
 
 	const data = {
 		ENV: getEnv(),
+		socialImage: getSignedSocialImage({ request, title: ROOT_TITLE }),
 		requestInfo: {
 			hints: getHints(request),
-			path: requestPath,
+			origin: url.origin,
+			path: url.pathname,
+			url: request.url,
 
 			userPrefs: {
 				theme: getTheme(request),
@@ -133,6 +160,17 @@ export async function loader({ request }: Route.LoaderArgs) {
 	}
 
 	return data
+}
+
+function Canonical() {
+	const { pathname } = useLocation()
+	const data = useRouteLoaderData<typeof loader>('root')
+	const origin = data?.requestInfo.origin
+	if (!origin) return null
+
+	return (
+		<link rel="canonical" href={removeTrailingSlash(`${origin}${pathname}`)} />
+	)
 }
 
 function Document({
@@ -150,12 +188,22 @@ function Document({
 		<html className={theme} lang="en">
 			<head>
 				<ClientHintCheck nonce={nonce} />
-				<Meta />
 				<meta
 					name="viewport"
 					content="width=device-width,initial-scale=1,viewport-fit=cover"
 				/>
+				<meta
+					name="theme-color"
+					content={theme === 'dark' ? '#0B0B0F' : '#FFFFFF'}
+				/>
+				<Meta />
+				<Canonical />
 				<Links />
+				<script
+					type="application/ld+json"
+					nonce={nonce}
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+				/>
 				<noscript>
 					<link href={noScriptStyles} rel="stylesheet" />
 				</noscript>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,12 +4,28 @@ import { HeroSection } from '@/components/home/hero-section'
 import { ProjectSection } from '@/components/home/project-section'
 import { SubstackSection } from '@/components/home/substack-section'
 import { Spacer } from '@/components/spacer'
+import { getSignedSocialImage } from '@/utils/cloudinary.server'
+import { getUrl } from '@/utils/helpers'
 import { getContentMdxListItems } from '@/utils/mdx.server'
+import { getRootRequestInfo, getSocialMetas } from '@/utils/seo'
 import { getFeaturedSubstackPosts } from '@/utils/substack.server'
 
 import { type Route } from './+types/_index'
 
 import { data, type HeadersArgs } from 'react-router'
+
+const PAGE_TITLE = 'Hani Husamuddin — Software Engineer & UI Designer'
+const PAGE_DESCRIPTION =
+	'Hani Husamuddin is a software engineer and UI designer helping teams build thoughtful, high-quality digital products.'
+
+export const meta: Route.MetaFunction = ({ loaderData, matches }) => {
+	return getSocialMetas({
+		url: getUrl(getRootRequestInfo(matches)),
+		title: PAGE_TITLE,
+		description: PAGE_DESCRIPTION,
+		image: loaderData?.socialImage,
+	})
+}
 
 export const handle = { surface: 'secondary' as const }
 
@@ -27,6 +43,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 		{
 			substackPosts,
 			projects: projects.slice(0, 4),
+			socialImage: getSignedSocialImage({ request, title: PAGE_TITLE }),
 		},
 		{
 			headers: {

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -5,21 +5,40 @@ import { FunFactsSection } from '@/components/about/fun-facts-section'
 import { AboutHero } from '@/components/about/hero-section'
 import { SubstackSection } from '@/components/home/substack-section'
 import { Spacer } from '@/components/spacer'
+import { getSignedSocialImage } from '@/utils/cloudinary.server'
+import { getUrl } from '@/utils/helpers'
+import { getRootRequestInfo, getSocialMetas } from '@/utils/seo'
 import { getFeaturedSubstackPosts } from '@/utils/substack.server'
 
 import { type Route } from './+types/about'
 
 import { data, type HeadersArgs } from 'react-router'
 
+const PAGE_TITLE = 'About | Hani Husamuddin'
+const PAGE_DESCRIPTION =
+	'Get to know Hani Husamuddin — a software engineer and UI designer building thoughtful digital products.'
+
+export const meta: Route.MetaFunction = ({ loaderData, matches }) => {
+	return getSocialMetas({
+		url: getUrl(getRootRequestInfo(matches)),
+		title: PAGE_TITLE,
+		description: PAGE_DESCRIPTION,
+		image: loaderData?.socialImage,
+	})
+}
+
 export function headers({ actionHeaders, loaderHeaders }: HeadersArgs) {
 	return actionHeaders ? actionHeaders : loaderHeaders
 }
 
-export const loader = async () => {
+export const loader = async ({ request }: Route.LoaderArgs) => {
 	const substackPosts = await getFeaturedSubstackPosts(3)
 
 	return data(
-		{ substackPosts },
+		{
+			substackPosts,
+			socialImage: getSignedSocialImage({ request, title: PAGE_TITLE }),
+		},
 		{
 			headers: {
 				'Cache-Control': 'private, max-age=3600',

--- a/app/routes/robots[.]txt.tsx
+++ b/app/routes/robots[.]txt.tsx
@@ -1,0 +1,18 @@
+import { type LoaderFunctionArgs } from 'react-router'
+
+export function loader({ request }: LoaderFunctionArgs) {
+	const domain = new URL(request.url).origin
+	const body = [
+		'User-agent: *',
+		'Allow: /',
+		'',
+		`Sitemap: ${domain}/sitemap.xml`,
+	].join('\n')
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain',
+			'Cache-Control': 'public, max-age=86400',
+		},
+	})
+}

--- a/app/routes/sitemap[.]xml.tsx
+++ b/app/routes/sitemap[.]xml.tsx
@@ -1,0 +1,44 @@
+import { removeTrailingSlash } from '@/utils/helpers'
+import { getContentMdxListItems } from '@/utils/mdx.server'
+
+import { type LoaderFunctionArgs } from 'react-router'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+	const domain = new URL(request.url).origin
+	const projects = await getContentMdxListItems('projects', { request })
+
+	const staticEntries = [
+		{ route: '/', priority: '1.0' },
+		{ route: '/about', priority: '0.8' },
+		{ route: '/works', priority: '0.8' },
+	]
+
+	const projectEntries = projects.map((project) => ({
+		route: `/works/${project.slug}`,
+		priority: '0.7',
+		lastmod: project.lastUpdated ?? project.publishedAt,
+	}))
+
+	const entries = [...staticEntries, ...projectEntries]
+
+	const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries
+	.map((entry) => {
+		const loc = removeTrailingSlash(`${domain}${entry.route}`)
+		const lastmod =
+			'lastmod' in entry && entry.lastmod
+				? `\n    <lastmod>${new Date(String(entry.lastmod)).toISOString()}</lastmod>`
+				: ''
+		return `  <url>\n    <loc>${loc}</loc>${lastmod}\n    <priority>${entry.priority}</priority>\n  </url>`
+	})
+	.join('\n')}
+</urlset>`
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'application/xml',
+			'Cache-Control': 'public, max-age=3600',
+		},
+	})
+}

--- a/app/routes/works.$slug.tsx
+++ b/app/routes/works.$slug.tsx
@@ -17,6 +17,9 @@ import {
 } from '@/utils/blog.server'
 import { useMdxComponent } from '@/utils/mdx'
 import { getMdxPage } from '@/utils/mdx.server'
+import { getSignedSocialImage } from '@/utils/cloudinary.server'
+import { getUrl } from '@/utils/helpers'
+import { getRootRequestInfo, getSocialMetas } from '@/utils/seo'
 import { getSessionId } from '@/utils/session.server'
 import { getServerTimeHeader } from '@/utils/timing.server'
 
@@ -76,7 +79,35 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 		throw data(null, { status: 404, headers })
 	}
 
-	return data({ page, meta }, { status: 200, headers })
+	const socialImage = getSignedSocialImage({
+		request,
+		title: page.frontmatter.title,
+		featuredImage: page.frontmatter.bannerLandscapeCloudinaryId,
+	})
+
+	return data({ page, meta, socialImage }, { status: 200, headers })
+}
+
+export const meta: Route.MetaFunction = ({ loaderData, matches }) => {
+	const requestInfo = getRootRequestInfo(matches)
+	const url = getUrl(requestInfo)
+
+	if (!loaderData?.page) {
+		return [
+			{ title: 'Work not found | Hani Husamuddin' },
+			{ name: 'description', content: 'This project could not be found.' },
+		]
+	}
+
+	const { frontmatter } = loaderData.page
+
+	return getSocialMetas({
+		url,
+		title: frontmatter.title,
+		description: frontmatter.description,
+		ogType: 'article',
+		image: loaderData.socialImage,
+	})
 }
 
 function useOnRead({

--- a/app/routes/works._index.tsx
+++ b/app/routes/works._index.tsx
@@ -9,14 +9,30 @@ import { FilterTag } from '@/components/ui/filter-tag'
 import { CallToAction } from '@/components/works/cta-section'
 import { WorksHero } from '@/components/works/hero-section'
 import { clsxm } from '@/utils/clsxm'
+import { getSignedSocialImage } from '@/utils/cloudinary.server'
+import { getUrl } from '@/utils/helpers'
 import { getContentMdxListItems } from '@/utils/mdx.server'
 import { useUpdateQueryStringValueWithoutNavigation } from '@/utils/misc'
+import { getRootRequestInfo, getSocialMetas } from '@/utils/seo'
 import { getServerTimeHeader } from '@/utils/timing.server'
 
 import { type Route } from './+types/works._index'
 
 import { PlusIcon } from '@phosphor-icons/react'
 import { data, type HeadersArgs, useSearchParams } from 'react-router'
+
+const PAGE_TITLE = 'Works | Hani Husamuddin'
+const PAGE_DESCRIPTION =
+	'A selection of projects and case studies by Hani Husamuddin, spanning software engineering and product design.'
+
+export const meta: Route.MetaFunction = ({ loaderData, matches }) => {
+	return getSocialMetas({
+		url: getUrl(getRootRequestInfo(matches)),
+		title: PAGE_TITLE,
+		description: PAGE_DESCRIPTION,
+		image: loaderData?.socialImage,
+	})
+}
 
 export function headers({ actionHeaders, loaderHeaders }: HeadersArgs) {
 	return actionHeaders ? actionHeaders : loaderHeaders
@@ -44,7 +60,11 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 	}
 
 	return data(
-		{ projects, tags: Array.from(tags) },
+		{
+			projects,
+			tags: Array.from(tags),
+			socialImage: getSignedSocialImage({ request, title: PAGE_TITLE }),
+		},
 		{
 			headers: {
 				'Cache-Control': 'private, max-age=3600',

--- a/app/utils/cloudinary.server.ts
+++ b/app/utils/cloudinary.server.ts
@@ -1,0 +1,49 @@
+import crypto from 'node:crypto'
+
+import { removeTrailingSlash } from '@/utils/helpers'
+import { getSocialImage } from '@/utils/images'
+
+// Signs a Cloudinary delivery URL so authenticated assets (our custom Satoshi
+// fonts) can be used in transformations. The signature is the first 8 URL-safe
+// base64 chars of sha1(<everything after /image/upload/> + api secret), inserted
+// as `s--<sig>--` right after `/image/upload/`.
+export function signCloudinaryUrl(url: string): string {
+	const secret = process.env.CLOUDINARY_SECRET_KEY
+	if (!secret) return url
+
+	const marker = '/image/upload/'
+	const idx = url.indexOf(marker)
+	if (idx === -1) return url
+
+	const prefix = url.slice(0, idx + marker.length)
+	const toSign = url.slice(idx + marker.length)
+	const signature = crypto
+		.createHash('sha1')
+		.update(toSign + secret)
+		.digest('base64')
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '')
+		.slice(0, 8)
+
+	return `${prefix}s--${signature}--/${toSign}`
+}
+
+// Builds a signed social-share image URL for a page. Must run on the server
+// (it needs the Cloudinary secret), so callers invoke it in loaders and pass
+// the result to the route's `meta` via loader data.
+export function getSignedSocialImage({
+	request,
+	title,
+	featuredImage,
+}: {
+	request: Request
+	title: string
+	featuredImage?: string
+}): string {
+	const url = new URL(request.url)
+	const displayUrl = removeTrailingSlash(`${url.host}${url.pathname}`)
+	return signCloudinaryUrl(
+		getSocialImage({ title, url: displayUrl, featuredImage }),
+	)
+}

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -32,4 +32,37 @@ function toErrorWithMessage(
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? useEffect : useLayoutEffect
 
-export { toErrorWithMessage, useIsomorphicLayoutEffect }
+export type RequestInfo = {
+	origin: string
+	path: string
+}
+
+function removeTrailingSlash(s: string): string {
+	return s.endsWith('/') ? s.slice(0, -1) : s
+}
+
+function getDomainUrl(requestInfo?: Pick<RequestInfo, 'origin'>): string {
+	return requestInfo?.origin ?? ''
+}
+
+// Absolute URL for the current request, e.g. https://hanihusam.com/works/foo.
+function getUrl(requestInfo?: RequestInfo): string {
+	return removeTrailingSlash(
+		`${requestInfo?.origin ?? ''}${requestInfo?.path ?? ''}`,
+	)
+}
+
+// Protocol-stripped URL used as the label printed on the social card,
+// e.g. hanihusam.com/works/foo.
+function getDisplayUrl(requestInfo?: RequestInfo): string {
+	return getUrl(requestInfo).replace(/^https?:\/\//, '')
+}
+
+export {
+	getDisplayUrl,
+	getDomainUrl,
+	getUrl,
+	removeTrailingSlash,
+	toErrorWithMessage,
+	useIsomorphicLayoutEffect,
+}

--- a/app/utils/images.ts
+++ b/app/utils/images.ts
@@ -137,6 +137,106 @@ async function getFetchBlurDataUrl(url: string) {
 	return dataUrl
 }
 
+//#region //*=========== Social share image ===========
+// Dynamic Open Graph / Twitter card images composed as a single Cloudinary
+// URL (adapted from kentcdodds.com). Layout: page title + name/url on the
+// left, a featured image cropped on the right, over a branded background.
+//
+// These IDs must exist in the `hanihusam` Cloudinary account. Update them to
+// match whatever you uploaded.
+const socialImageConfig = {
+	// 2400x1256 branded backdrop (no text/photo baked in).
+	background: 'bapak2.dev/images/social-background_babqok',
+	// Square transparent profile/brand mark (rendered as a circle).
+	profile: 'bapak2.dev/images/profile-transparent_x6bhfg',
+	// Right-side image used when a page has no banner of its own.
+	defaultFeaturedImage:
+		'bapak2.dev/images/placeholder-image-transparent_tix6cc',
+	// Site's Satoshi typeface, uploaded as raw + authenticated fonts at the root
+	// (no folder — Cloudinary's text-layer parser can't resolve nested font
+	// paths). Because the fonts are authenticated, the delivery URL must be
+	// signed with the Cloudinary secret; see `signCloudinaryUrl` in
+	// `cloudinary.server.ts`, which is why social image URLs are built in loaders.
+	fontBold: 'Satoshi-Bold.woff2',
+	fontRegular: 'Satoshi-Regular.woff2',
+} as const
+
+// Cloudinary references nested public IDs in layers with `:` instead of `/`.
+function toLayerId(publicId: string): string {
+	return publicId.replace(/\//g, ':')
+}
+
+// Cloudinary text layers need the text double-URI-encoded.
+function doubleEncode(s: string): string {
+	return encodeURIComponent(encodeURIComponent(s))
+}
+
+// Emojis break Cloudinary text layers, so strip them and collapse whitespace.
+function emojiStrip(s: string): string {
+	return s
+		.replace(/\p{Extended_Pictographic}/gu, '')
+		.split(' ')
+		.filter(Boolean)
+		.join(' ')
+		.trim()
+}
+
+function getSocialImage({
+	title,
+	featuredImage = socialImageConfig.defaultFeaturedImage,
+	url,
+	name = 'Hani Husamuddin',
+}: {
+	title: string
+	featuredImage?: string
+	url: string
+	name?: string
+}): string {
+	const { background, profile, fontBold, fontRegular } = socialImageConfig
+
+	// 24-column x 12-row grid over the 2400x1256 canvas ($gw=100, $gh~104.6).
+	const vars = `$th_1256,$tw_2400,$gw_$tw_div_24,$gh_$th_div_12`
+
+	const encodedTitle = doubleEncode(emojiStrip(title))
+	const titleSection = `co_white,c_fit,g_north_west,w_$gw_mul_12,h_$gh_mul_6,x_$gw_mul_1.5,y_$gh_mul_1.5,l_text:${fontBold}_110:${encodedTitle}`
+
+	const profileSection = `c_fill,g_north_west,r_max,w_$gw_mul_2,h_$gh_mul_2,x_$gw_mul_1.5,y_$gh_mul_8.8,l_${toLayerId(profile)}`
+
+	const encodedName = doubleEncode(emojiStrip(name))
+	const nameSection = `co_white,c_fit,g_north_west,w_$gw_mul_9,x_$gw_mul_4,y_$gh_mul_8.9,l_text:${fontBold}_50:${encodedName}`
+
+	const encodedUrl = doubleEncode(emojiStrip(url))
+	const urlSection = `co_rgb:9ca3af,c_fit,g_north_west,w_$gw_mul_9,x_$gw_mul_4,y_$gh_mul_10,l_text:${fontRegular}_36:${encodedUrl}`
+
+	const featuredImageIsRemote = featuredImage.startsWith('http')
+	const featuredImageId = featuredImageIsRemote
+		? toBase64(featuredImage)
+		: toLayerId(featuredImage)
+	const featuredImageLayerType = featuredImageIsRemote ? 'l_fetch:' : 'l_'
+	const featuredImageSection = `c_fill,ar_3:4,r_24,g_east,h_$gh_mul_10,x_$gw,${featuredImageLayerType}${featuredImageId}`
+
+	const backgroundSection = `c_fill,w_$tw,h_$th/${background}`
+
+	return [
+		`https://res.cloudinary.com/${cloudName}/image/upload`,
+		vars,
+		titleSection,
+		profileSection,
+		nameSection,
+		urlSection,
+		featuredImageSection,
+		backgroundSection,
+	].join('/')
+}
+
+function toBase64(s: string): string {
+	if (typeof window === 'undefined') {
+		return Buffer.from(s).toString('base64')
+	}
+	return window.btoa(s)
+}
+//#endregion //*=========== Social share image ===========
+
 async function getDataUrlForImage(imageUrl: string) {
 	try {
 		const res = await fetch(imageUrl)
@@ -157,5 +257,7 @@ export {
 	getFetchImageBuilder,
 	getImageBuilder,
 	getImgProps,
+	getSocialImage,
+	socialImageConfig,
 }
 export type { ImageBuilder }

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -1,0 +1,59 @@
+import { type RequestInfo } from '@/utils/helpers'
+import { getSocialImage } from '@/utils/images'
+
+const SITE_NAME = 'Hani Husamuddin'
+const TWITTER_HANDLE = '@hanihusam'
+
+export const DEFAULT_TITLE = 'Hani Husamuddin'
+export const DEFAULT_DESCRIPTION =
+	'A professional freelancer who could help you solve your software engineer and UI design problem'
+
+// Pulls the request info exposed by the root loader out of a route's meta
+// `matches`, so child-route meta functions can build absolute URLs.
+export function getRootRequestInfo(
+	matches: Array<{ id: string; loaderData?: unknown } | undefined>,
+): RequestInfo | undefined {
+	const root = matches.find((m) => m?.id === 'root')
+	const data = root?.loaderData as { requestInfo?: RequestInfo } | undefined
+	return data?.requestInfo
+}
+
+// Builds the full set of SEO/social meta descriptors for a page. Pass a
+// pre-built `image` (via getSocialImage) or let it generate a generic card.
+export function getSocialMetas({
+	url,
+	title = DEFAULT_TITLE,
+	description = DEFAULT_DESCRIPTION,
+	image,
+	keywords = '',
+	ogType = 'website',
+}: {
+	url: string
+	title?: string
+	description?: string
+	image?: string
+	keywords?: string
+	ogType?: 'website' | 'article'
+}) {
+	const socialImage = image ?? getSocialImage({ title, url })
+
+	return [
+		{ title },
+		{ name: 'description', content: description },
+		{ name: 'keywords', content: keywords },
+		{ name: 'image', content: socialImage },
+		{ property: 'og:url', content: url },
+		{ property: 'og:title', content: title },
+		{ property: 'og:description', content: description },
+		{ property: 'og:image', content: socialImage },
+		{ property: 'og:type', content: ogType },
+		{ property: 'og:site_name', content: SITE_NAME },
+		{ name: 'twitter:card', content: 'summary_large_image' },
+		{ name: 'twitter:creator', content: TWITTER_HANDLE },
+		{ name: 'twitter:site', content: TWITTER_HANDLE },
+		{ name: 'twitter:title', content: title },
+		{ name: 'twitter:description', content: description },
+		{ name: 'twitter:image', content: socialImage },
+		{ name: 'twitter:image:alt', content: title },
+	]
+}

--- a/public/favicons/manifest.json
+++ b/public/favicons/manifest.json
@@ -1,5 +1,10 @@
 {
-	"name": "App",
+	"name": "Hani Husamuddin",
+	"short_name": "Hani",
+	"start_url": "/",
+	"display": "standalone",
+	"theme_color": "#0B0B0F",
+	"background_color": "#FFFFFF",
 	"icons": [
 		{
 			"src": "/favicons/android-icon-36x36.png",


### PR DESCRIPTION
## Summary

Comprehensive SEO implementation including per-route meta, dynamic Cloudinary OG images with signed URLs and site Satoshi font, canonical links, sitemap/robots, and JSON-LD structured data.

## Changes

- **Dynamic OG images**: Left-text/right-image Cloudinary cards with site Satoshi font (authenticated uploads, SHA-1 signed URLs)
- **SEO meta helper** (`seo.ts`): `getSocialMetas()` for og:* + twitter:* tags
- **Per-route meta**: Works/$slug derives from frontmatter; home/about/works-list get specific titles/descriptions
- **Server-side signing** (`cloudinary.server.ts`): Fonts require authenticated delivery; URLs signed in loaders and passed via loaderData
- **Canonical links** + **Person JSON-LD** on every page (in Document head, not affected by child route meta replacement)
- **sitemap.xml** (6 URLs with lastmod), **robots.txt**, fixed **web manifest**
- **URL helpers**: `getDomainUrl`, `getUrl`, `getDisplayUrl`, `removeTrailingSlash`

## Notes

- Satoshi fonts uploaded to Cloudinary as `resource_type: raw`, `type: authenticated`, **at root** (no folder — nested paths break the text-layer parser)
- Social image URLs built in **route loaders** (need the secret), passed to `meta` via `loaderData.socialImage` to avoid exposing the secret to the client
- Secret **not** leaked to client bundle (server-only `.server.ts` correctly stripped)

## Prod follow-up

Add Fly.io secrets: `CLOUDINARY_SECRET_KEY` and `CLOUDINARY_API_KEY`