### PR TITLE
feat: polish site motion and unify the underline wipe

### DIFF
--- a/app/components/about/hero-section.tsx
+++ b/app/components/about/hero-section.tsx
@@ -2,7 +2,36 @@ import { Grid } from '@/components/grid'
 import { Display, Text } from '@/components/typography'
 import { DotGrid } from '@/components/ui/dot-grid'
 
+import { motion, useReducedMotion } from 'motion/react'
+
+// Matches the ease-out-quart motion token in theme.css.
+const EASE_OUT_QUART = [0.165, 0.84, 0.44, 1] as const
+
 export function AboutHero() {
+	const shouldReduceMotion = useReducedMotion()
+
+	// Staggered entrance on first mount. Skipping `initial` under reduced motion
+	// keeps the SSR-visible content from ever being hidden (same contract as Reveal).
+	const fadeUp = (delay: number) =>
+		shouldReduceMotion
+			? {}
+			: {
+					initial: { opacity: 0, y: 12 },
+					animate: { opacity: 1, y: 0 },
+					transition: { duration: 0.5, ease: EASE_OUT_QUART, delay },
+				}
+
+	// Avatar slides in from the right. The transform lives on this wrapper, not on
+	// the box below — that box uses responsive Tailwind `translate-x-*` utilities
+	// which Motion's inline transform would otherwise clobber.
+	const slideInFromRight = shouldReduceMotion
+		? {}
+		: {
+				initial: { opacity: 0, x: 48 },
+				animate: { opacity: 1, x: 0 },
+				transition: { duration: 0.6, ease: EASE_OUT_QUART },
+			}
+
 	return (
 		<Grid as="section" className="relative pt-40 md:pb-16 lg:pb-40">
 			<DotGrid
@@ -14,20 +43,27 @@ export function AboutHero() {
 
 			<div className="relative col-span-full flex items-end">
 				{/* Floating cutout avatar over a tinted square */}
-				<div className="absolute top-0 right-0 flex aspect-square w-100 translate-x-[28%] -translate-y-1/3 items-center justify-center overflow-visible rounded-2xl border-(--border-primary) bg-sky-50 md:translate-x-[40%] md:translate-y-0 lg:translate-x-0 dark:bg-sky-900">
-					<img
-						src="/images/avatar-side.png"
-						alt="Portrait of Han"
-						width={512}
-						height={512}
-						className="absolute top-1/2 left-1/2 flex max-w-none shrink-0 -translate-x-1/2 -translate-y-1/2"
-					/>
-				</div>
+				<motion.div {...slideInFromRight} className="absolute top-0 right-0">
+					<div className="relative flex aspect-square w-100 translate-x-[28%] -translate-y-1/3 items-center justify-center overflow-visible rounded-2xl border-(--border-primary) bg-sky-50 md:translate-x-[40%] md:translate-y-0 lg:translate-x-0 dark:bg-sky-900">
+						<img
+							src="/images/avatar-side.png"
+							alt="Portrait of Han"
+							width={512}
+							height={512}
+							className="absolute top-1/2 left-1/2 flex max-w-none shrink-0 -translate-x-1/2 -translate-y-1/2"
+						/>
+					</div>
+				</motion.div>
 
 				<div className="relative z-1 mt-82 flex flex-col gap-6 md:gap-12">
-					<Display>Hi there! I&apos;m Han.</Display>
+					<motion.div {...fadeUp(0.1)}>
+						<Display>Hi there! I&apos;m Han.</Display>
+					</motion.div>
 
-					<div className="flex flex-col gap-4 md:max-w-[60%]">
+					<motion.div
+						{...fadeUp(0.18)}
+						className="flex flex-col gap-4 md:max-w-[60%]"
+					>
 						<Text variant="lead" as="p">
 							I started building on the web in 2018 and haven&apos;t stopped
 							since.
@@ -42,14 +78,14 @@ export function AboutHero() {
 							Besides freelancing, I&apos;m building{' '}
 							<a
 								href="https://coverse.id"
-								className="text-sunset-400 font-medium hover:underline"
+								className="underlined text-sunset-400 font-medium"
 							>
 								Coverse
 							</a>
 							, a studio specializing in layout and deck templates, from
 							Yogyakarta, Indonesia.
 						</Text>
-					</div>
+					</motion.div>
 				</div>
 			</div>
 		</Grid>

--- a/app/components/home/hero-section.tsx
+++ b/app/components/home/hero-section.tsx
@@ -6,14 +6,39 @@ import Logo from '@/components/ui/logo'
 import { getImageBuilder, getImgProps } from '@/utils/images'
 
 import { ArrowCircleRightIcon, ArrowDownIcon } from '@phosphor-icons/react'
+import { motion, useReducedMotion } from 'motion/react'
+
+// Matches the ease-out-quart / duration-slower motion tokens in theme.css.
+const EASE_OUT_QUART = [0.165, 0.84, 0.44, 1] as const
 
 export function HeroSection() {
+	const shouldReduceMotion = useReducedMotion()
+
+	// Staggered fade+rise on first mount. Under prefers-reduced-motion we skip
+	// `initial` so the SSR-visible content is never hidden (same contract as
+	// the Reveal component).
+	const fadeUp = (delay: number) =>
+		shouldReduceMotion
+			? {}
+			: {
+					initial: { opacity: 0, y: 12 },
+					animate: { opacity: 1, y: 0 },
+					transition: { duration: 0.5, ease: EASE_OUT_QUART, delay },
+				}
+
 	return (
 		<div className="bg-(--surface-primary)">
 			<Grid className="min-h-screen place-content-center pt-20">
 				<Logo className="absolute top-8" />
 
-				<img
+				<motion.img
+					{...(shouldReduceMotion
+						? {}
+						: {
+								initial: { opacity: 0 },
+								animate: { opacity: 1 },
+								transition: { duration: 0.3, ease: EASE_OUT_QUART },
+							})}
 					className="absolute top-0 right-0 hidden h-auto w-87.5 max-w-2/3 translate-x-[25%] translate-y-[20vh] md:top-auto md:right-auto md:bottom-0 md:left-0 md:block md:w-lg md:translate-x-[-16%] md:translate-y-0 lg:left-1/2 lg:w-3xl lg:-translate-x-1/2"
 					{...getImgProps(
 						getImageBuilder(
@@ -32,7 +57,10 @@ export function HeroSection() {
 				/>
 
 				<div className="col-span-full flex flex-col items-start gap-y-8 self-stretch md:h-[50vh] lg:flex-row lg:items-center">
-					<div className="flex flex-col justify-end gap-y-8 lg:h-77.5">
+					<motion.div
+						{...fadeUp(0.1)}
+						className="flex flex-col justify-end gap-y-8 lg:h-77.5"
+					>
 						<Display>I'm Han</Display>
 						<ButtonLink
 							to="#projects"
@@ -41,8 +69,11 @@ export function HeroSection() {
 						>
 							View My Works
 						</ButtonLink>
-					</div>
-					<div className="flex w-full flex-col gap-y-4 md:ml-auto md:w-90 lg:w-100">
+					</motion.div>
+					<motion.div
+						{...fadeUp(0.18)}
+						className="flex w-full flex-col gap-y-4 md:ml-auto md:w-90 lg:w-100"
+					>
 						<H3 className="text-(--text-paragraph)">
 							A Frontend & UI Engineer based in Yogyakarta, Indonesia.
 						</H3>
@@ -68,7 +99,7 @@ export function HeroSection() {
 								More about me
 							</ButtonLink>
 						</div>
-					</div>
+					</motion.div>
 				</div>
 			</Grid>
 		</div>

--- a/app/components/projects/project-card.tsx
+++ b/app/components/projects/project-card.tsx
@@ -45,7 +45,7 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
 											},
 										},
 									)}
-									className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-slow) motion-safe:ease-in-out motion-safe:group-hover:scale-105"
+									className="focus-ring motion-safe:ease w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-base) motion-safe:group-hover:scale-105"
 									loading="lazy"
 								/>
 							}
@@ -80,7 +80,7 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
 											},
 										},
 									)}
-									className="focus-ring w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-slow) motion-safe:ease-in-out motion-safe:group-hover:scale-105"
+									className="focus-ring motion-safe:ease w-full object-cover object-center will-change-transform motion-safe:transition-transform motion-safe:duration-(--duration-base) motion-safe:group-hover:scale-105"
 									loading="lazy"
 								/>
 							}

--- a/app/components/typography.tsx
+++ b/app/components/typography.tsx
@@ -40,7 +40,7 @@ type TextProps = {
 const fontSize = {
 	display:
 		'font-black text-5xl md:text-8xl md:leading-(--display-leading) leading-(--h1-leading-desktop)',
-	h1: 'font-black text-4xl md:text-5xl leading-(--h1-leading-mobile) md:leading-(--h1-leading-desktop) md:text-5xl',
+	h1: 'font-black text-4xl md:text-5xl leading-(--h1-leading-mobile) md:leading-(--h1-leading-desktop)',
 	h2: 'font-bold text-3xl md:text-4xl leading-(--h2-leading-mobile) md:leading-(--h2-leading-desktop)',
 	h3: 'font-bold text-2xl md:text-3xl leading-(--h3-leading-mobile) md:leading-(--h3-leading-desktop)',
 	h4: 'font-medium text-xl md:text-2xl leading-(--h4-leading-mobile) md:leading-(--h4-leading-desktop)',

--- a/app/components/ui/clipboard-copy-button.tsx
+++ b/app/components/ui/clipboard-copy-button.tsx
@@ -34,8 +34,7 @@ export function ClipboardCopyButton({
 		async function transition() {
 			switch (state) {
 				case State.Copy: {
-					const res = await copyToClipboard(value)
-					console.info('copied', res)
+					await copyToClipboard(value)
 					setState(State.Copied)
 					break
 				}
@@ -66,16 +65,20 @@ export function ClipboardCopyButton({
 			<span className="relative inline-flex size-6 shrink-0">
 				<span
 					className={clsxm(
-						'absolute inset-0 transition-all duration-(--duration-base)',
-						copied ? 'opacity-0 blur-sm' : 'opacity-100 blur-none',
+						'ease-out-quart absolute inset-0 transition-all duration-(--duration-slow)',
+						copied
+							? 'scale-50 opacity-0 blur-sm'
+							: 'scale-100 opacity-100 blur-none',
 					)}
 				>
 					<CopyIcon className="size-full" />
 				</span>
 				<span
 					className={clsxm(
-						'absolute inset-0 transition-all duration-(--duration-base)',
-						copied ? 'opacity-100 blur-none' : 'opacity-0 blur-sm',
+						'ease-out-quart absolute inset-0 transition-all duration-(--duration-slow)',
+						copied
+							? 'scale-100 opacity-100 blur-none'
+							: 'scale-50 opacity-0 blur-sm',
 					)}
 				>
 					<CheckCircleIcon weight="fill" className="size-full" />

--- a/app/components/ui/filter-tag.tsx
+++ b/app/components/ui/filter-tag.tsx
@@ -16,7 +16,7 @@ function FilterTag({ tag, selected, onChange, disabled }: FilterTagProps) {
 			className={clsxm(
 				'relative inline-flex cursor-pointer items-center justify-center select-none',
 				'rounded-full px-4 py-3',
-				'transition-colors duration-(--duration-fast)',
+				'transition duration-(--duration-fast) active:scale-[0.97]',
 				{
 					'border border-(--border-primary) bg-(--filter-tag-surface-default)':
 						!selected && !disabled,

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -42,7 +42,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 	return data(
 		{
 			substackPosts,
-			projects: projects.slice(0, 4),
+			projects: projects.slice(0, 3),
 			socialImage: getSignedSocialImage({
 				request,
 				title: 'Crafting interfaces by intersecting design and code.',

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -9,48 +9,36 @@ light-mode {
 	display: none;
 }
 
-.underlined {
-	position: relative;
-	text-decoration: none !important;
-	white-space: nowrap;
+/*
+ * Content underline — the single implementation for the whole site. The bar
+ * wipes in from the left on hover/focus.
+ *
+ * A gradient background is used instead of a ::after bar so the underline
+ * tracks inline text that wraps across lines (prose links do). The duration
+ * token is re-zeroed under prefers-reduced-motion, so it just appears there.
+ *
+ * `.prose a` is included here (rather than in prose.css) so there is one rule
+ * to maintain. Specificity (0,1,1) already beats the typography plugin's
+ * `.prose :where(a)` (0,1,0), so load order doesn't matter. Opt-outs for
+ * headings anchors and callout links live in prose.css.
+ */
+.underlined,
+.prose a {
+	text-decoration: none;
+	background-image: linear-gradient(currentColor, currentColor);
+	background-repeat: no-repeat;
+	background-position: 0 100%;
+	background-size: 0% 2px;
+	transition: background-size var(--duration-base) ease;
 }
 
-.underlined:focus {
+.underlined:hover,
+.underlined:focus,
+.active.underlined,
+.prose a:hover,
+.prose a:focus {
+	background-size: 100% 2px;
 	outline: none;
-	text-decoration: none !important;
-}
-
-.underlined:after {
-	content: '';
-	height: 2px;
-	transform: scaleX(0);
-	transition: transform var(--duration-base) ease;
-	transform-origin: left;
-	left: 0;
-	bottom: -4px;
-	width: 100%;
-	display: block;
-	position: absolute;
-}
-
-.underlined:hover:after,
-.underlined:focus:after,
-.active.underlined:after {
-	background-color: currentColor;
-	transform: scaleX(1);
-}
-
-@media (prefers-reduced-motion) {
-	.underlined:after {
-		opacity: 0;
-		transition: opacity var(--duration-base) ease;
-	}
-
-	.underlined:hover:after,
-	.underlined:focus:after,
-	.active.underlined:after {
-		opacity: 1;
-	}
 }
 
 /* Toggle Switch Theme */

--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -10,15 +10,7 @@
 	font-size: 1.125rem;
 }
 
-.prose a {
-	text-decoration: none;
-}
-
-.prose a:hover,
-.prose a:focus {
-	text-decoration: underline;
-	outline: none;
-}
+/* Content links inherit the underline wipe from `.underlined` in app.css. */
 
 .prose strong {
 	font-weight: 500;
@@ -409,12 +401,19 @@ pre {
 	margin-left: -200px;
 }
 
+/*
+ * Callout links stay permanently underlined for affordance against the tinted
+ * background, so they opt out of the wipe — otherwise hovering would stack a
+ * second, animated bar under the static one.
+ */
 .prose callout-muted a,
 .prose callout-info a,
 .prose callout-warning a,
 .prose callout-danger a,
 .prose callout-success a {
 	text-decoration: underline;
+	background-image: none;
+	transition: none;
 }
 
 .prose callout-muted p,
@@ -546,7 +545,13 @@ pre {
  * The autolinked heading anchor stays for deep-linking but is invisible — no
  * leading `#`. Hovering the heading underlines its text instead.
  */
-.hash-anchor {
+/*
+ * Selector is `.prose a.hash-anchor` (0,2,1) so the wipe opt-out below actually
+ * beats `.prose a` (0,1,1). The anchor is a full-width overlay, so without this
+ * it would paint a bar across the whole heading on hover — on top of the
+ * heading's own text-decoration underline.
+ */
+.prose a.hash-anchor {
 	display: inline-flex;
 	width: 100%;
 	align-items: center;
@@ -557,8 +562,26 @@ pre {
 	transition: none;
 }
 
+/*
+ * Headings get the same left→right wipe as content links. The heading text is a
+ * bare text node with no inline wrapper, so the gradient has to sit on the
+ * heading box itself — `fit-content` shrinks that box to hug the text, so the
+ * bar spans the text rather than the full column. It also tightens the
+ * `.hash-anchor` overlay (width: 100%) to the text, so hovering the empty space
+ * beside a heading no longer triggers it.
+ *
+ * `text-decoration` is not used here because it cannot be animated.
+ */
+.prose :where(h1, h2, h3, h4) {
+	width: fit-content;
+	background-image: linear-gradient(currentColor, currentColor);
+	background-repeat: no-repeat;
+	background-position: 0 100%;
+	background-size: 0% 2px;
+	transition: background-size var(--duration-base) ease;
+}
+
 .prose :where(h1, h2, h3, h4):hover {
-	text-decoration: underline;
-	text-underline-offset: 4px;
+	background-size: 100% 2px;
 }
 /* #endregion  /**======== Hash Anchor =========== */

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -36,6 +36,11 @@
 		animation-name: slideDownAndFade;
 	}
 
+	/* Exit — reuses the fast token so it's re-zeroed under reduced motion. */
+	.TooltipContent[data-state='closed'] {
+		animation-name: fadeOut;
+	}
+
 	@keyframes slideDownAndFade {
 		from {
 			opacity: 0;
@@ -44,6 +49,17 @@
 		to {
 			opacity: 1;
 			transform: translateY(0);
+		}
+	}
+
+	@keyframes fadeOut {
+		from {
+			opacity: 1;
+			transform: translateY(0);
+		}
+		to {
+			opacity: 0;
+			transform: translateY(-2px);
 		}
 	}
 }

--- a/contents/projects/fix-storybook-addon-apollo-client.mdx
+++ b/contents/projects/fix-storybook-addon-apollo-client.mdx
@@ -2,7 +2,7 @@
 title: Fixing storybook-addon-apollo-client for Storybook 10
 publishedAt: 2025-12-16
 lastUpdated: 2025-12-16
-description: >
+description:
   Diagnosed two separate breakages in a community Storybook addon after
   upgrading to Apollo Client v4 and Storybook 10. One was a moved import path.
   The other was a subtle cache conflict that nobody had named yet.


### PR DESCRIPTION
## Motion

- **Hero entrances.** Home and about heroes now animate in on first mount with a stagger; the about avatar slides in from the right. Both skip `initial` under `prefers-reduced-motion` so SSR content is never hidden (same contract as `Reveal`).
- **FilterTag** gets an `active:scale-[0.97]` press for tactile feedback.
- **Project card image zoom** sped up: `ease-in-out`/`--duration-slow` → `ease`/`--duration-base`, so hover-in responds sooner.
- **Tooltip exit** animation added (`data-state='closed'`), reusing the fast token so it re-zeros under reduced motion. Kept to the top side only.

## Underline wipe

Content underlines now wipe in from the left. This turned out to need more than a new rule:

- **Collapsed two implementations into one.** `.underlined` used an `::after` + `scaleX` bar; prose used a gradient. Now a single rule covers `.underlined, .prose a`. The gradient technique is used because it tracks inline text that wraps across lines, which `::after` cannot.
- **Fixed a specificity bug.** The `.hash-anchor` opt-out `(0,1,0)` lost to `.prose a` `(0,1,1)`, so hovering a heading painted a gradient bar across the *full column width* on top of the heading's own underline. Selector is now `.prose a.hash-anchor` `(0,2,1)`.
- **Callout links** opt out of the wipe — they keep a static underline for affordance against the tinted background, and were otherwise stacking two bars on hover.
- **Headings wipe too.** `text-decoration` cannot be animated, so headings use the gradient with `width: fit-content` to hug their text (verified: box shrinks to the exact text width inside the column). This also tightens the `.hash-anchor` overlay, so hovering the empty space beside a heading no longer triggers it.

## Verification

Driven in a browser, not just typechecked. Confirmed on a prose page that links and headings both report `background-size: 0% → 100% 2px` anchored at `background-position: 0` over `--duration-base`, with `text-decoration: none`.

## Also included

Pre-existing working-tree changes that were bundled in at the repo owner's request: featured projects `4 → 3`, a duplicate typography class removed, a leftover `console.info` dropped, and an MDX frontmatter tweak (`description: >` → `description:`). The pre-commit hook normalized some accidental non-repo-style reformatting back to oxfmt style.