### PR TITLE
fix: trust Fly's proxy so absolute URLs are https

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,13 @@ const primaryHost = 'hanihusam.com'
 
 const app = express()
 
+// Fly terminates TLS at its edge and forwards plain HTTP to this process, so
+// without this Express reports req.protocol as 'http'. That protocol ends up in
+// every request.url the React Router handler sees, and from there in og:url,
+// rel=canonical, and the signed og:image URL — all of which must be absolute
+// https for scrapers and search engines. One hop: Fly's proxy.
+app.set('trust proxy', 1)
+
 app.use(compression())
 app.disable('x-powered-by')
 


### PR DESCRIPTION
Follow-up to #153.

## The problem

Every absolute URL the app emits is currently `http://`, on production:

```
og:url    → http://hanihusam.com
canonical → http://hanihusam.com
og:image  → http://hanihusam.com/resources/og-image?...
```

Fly terminates TLS at its edge and forwards plain HTTP to the app. `server.js` already read `X-Forwarded-Proto` by hand for the CORS header, but never told Express to trust the proxy — so `req.protocol` stayed `http`, and that protocol propagated into every `request.url` the React Router handler saw.

## Why it matters now

This is **pre-existing**, not introduced by #153 — but #153 made it consequential. Previously `og:image` was an absolute Cloudinary `https://` URL, so the broken origin never touched the card. Now the app's own origin *is* the image host.

The http URL does 301 to https and serves the PNG correctly, but scrapers don't reliably follow redirects for card images (LinkedIn in particular), so cards can silently fail to render on some platforms. The http `og:url` / `canonical` is an SEO smell independently.

## The fix

`app.set('trust proxy', 1)` — one hop, Fly's proxy.

## Verified locally

Production build, simulating Fly's edge headers:

| | before | after |
| --- | --- | --- |
| `og:url` | `http://hanihusam.com` | `https://hanihusam.com` |
| `canonical` | `http://hanihusam.com` | `https://hanihusam.com` |
| `og:image` | `http://hanihusam.com/...` | `https://hanihusam.com/...` |

- Without proxy headers (local dev) it correctly stays `http://localhost` — no dev regression
- Signed OG URLs are unaffected by the origin change: the signature covers `template\0version\0params`, not the origin. Confirmed a card still renders `200` / `image/png` after the origin flipped.
- `validate` (lint + typecheck + build) and `check:og` (37 checks) pass

## Merge note

Please merge this on its own and let the deploy finish before merging anything else — #153's deploy failed purely because three PRs merged within 70s and raced for the Fly machine lease.