### PR TITLE
Feat: animate active navigation indicator

### DIFF
--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -3,7 +3,9 @@ import { SubstackLogo } from '@/components/writing/substack-logo'
 import NavigationItem from './ui/navigation-item'
 import ThemeSwitcher from './ui/theme-switcher'
 
-import { HouseIcon, WrenchIcon } from '@phosphor-icons/react'
+import { HouseIcon, WrenchIcon, UserCircleIcon } from '@phosphor-icons/react'
+import { useLocation, matchPath } from 'react-router'
+import { clsxm } from '@/utils/clsxm'
 
 const links = [
 	{
@@ -18,15 +20,43 @@ const links = [
 		icon: WrenchIcon,
 	},
 	{
+		href: '/about',
+		label: 'About',
+		icon: UserCircleIcon,
+	},
+	{
 		href: 'https://bapak2dev.substack.com/',
 		label: 'Substack',
 		icon: SubstackLogo,
 	},
 ]
+const indicatorPositions = [
+	'translate-x-0',
+	'translate-x-10',
+	'translate-x-20',
+] as const
 
 export function Navigation() {
+	const { pathname } = useLocation()
+
+	const activeIndex = links.findIndex(
+		({ href }) =>
+			href.startsWith('/') &&
+			matchPath({ path: href, end: href === '/' }, pathname),
+	)
+
 	return (
 		<nav className="fixed inset-x-0 bottom-8 z-20 mx-auto flex w-fit items-center rounded-md border border-(--border-primary) bg-(--surface-primary) shadow-lg transition-colors">
+			<span
+				aria-hidden
+				className={clsxm(
+					'pointer-events-none absolute top-1 left-1 size-9 rounded-md',
+					'bg-(--nav-item-surface-active) transition-transform',
+					'duration-(--duration-base) ease-in-out-quart',
+					activeIndex === -1 && 'opacity-0',
+					activeIndex !== -1 && indicatorPositions[activeIndex],
+				)}
+			/>
 			{links.map((link, idx) => (
 				<NavigationItem
 					className={idx === 0 ? 'ml-1' : ''}

--- a/app/components/ui/navigation-item.tsx
+++ b/app/components/ui/navigation-item.tsx
@@ -30,12 +30,23 @@ export default function NavigationItem({
 					<NavLink
 						to={href}
 						className={clsxm(
-							'group relative my-1 mr-1 grid size-9 place-items-center rounded-md focus:outline-none',
+							'group relative z-10 my-1 mr-1 grid size-9 place-items-center',
+							'rounded-md focus:outline-none',
 							className,
 						)}
 					>
-						<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-(--duration-fast) group-hover:opacity-100 group-focus:opacity-100 group-aria-[current=page]:opacity-100" />
-						<span className="relative">{children}</span>
+						<span
+							className={clsxm(
+								'relative text-(--nav-item-icon-default)',
+								'transition-colors duration-(--duration-fast) ease-hover',
+								'group-hover:text-(--nav-item-icon-hover)',
+								'group-focus-visible:text-(--nav-item-icon-active)',
+								'group-aria-[current=page]:text-(--nav-item-icon-active)',
+								'[.group[aria-current=page]:not(:hover):not(:focus-visible)_&]:delay-(--duration-base)',
+							)}
+						>
+							{children}
+						</span>
 					</NavLink>
 				</Trigger>
 				<Content className="TooltipContent" sideOffset={5}>

--- a/app/components/ui/theme-switcher.tsx
+++ b/app/components/ui/theme-switcher.tsx
@@ -30,7 +30,7 @@ export default function ThemeSwitcher() {
 							aria-live="polite"
 							className="toggle-theme-switcher group relative m-1 grid size-9 cursor-pointer place-items-center overflow-hidden rounded-md p-2 text-(--icon-primary) focus:outline-none"
 						>
-							<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-(--duration-fast) group-hover:opacity-100 group-focus:opacity-100" />
+							<span className="ease absolute inset-0 rounded-md bg-(--nav-item-surface-active) opacity-0 transition-opacity duration-(--duration-fast) group-hover:opacity-100 group-focus-visible:opacity-100" />
 							{/* Moon icon */}
 							<svg
 								id="moon-icon"

--- a/app/styles/theme.css
+++ b/app/styles/theme.css
@@ -244,6 +244,9 @@
 
 	/* Component — Nav item */
 	--nav-item-surface-active: var(--color-sunset-50);
+	--nav-item-icon-active: var(--color-neutral-950);
+	--nav-item-icon-hover: var(--color-neutral-950);
+	--nav-item-icon-default: var(--color-neutral-600);
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -323,6 +326,10 @@
 
 	/* Component — Nav item */
 	--nav-item-surface-active: var(--color-sunset-950);
+	--nav-item-icon-active: var(--color-neutral-50);
+	--nav-item-icon-hover: var(--color-neutral-50);
+	--nav-item-icon-default: var(--color-neutral-200);
+
 
 	/* Shadows — increased opacity on dark */
 	--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);

--- a/app/styles/theme.css
+++ b/app/styles/theme.css
@@ -330,7 +330,6 @@
 	--nav-item-icon-hover: var(--color-neutral-50);
 	--nav-item-icon-default: var(--color-neutral-200);
 
-
 	/* Shadows — increased opacity on dark */
 	--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
 	--shadow-md:


### PR DESCRIPTION
## Summary

- Add the About destination and a route-aware shared background indicator to the floating navigation.
- Dim inactive icons while keeping hover feedback icon-only.
- Move the active background before transitioning the active icon color.
- Prevent pointer clicks from leaving the theme switcher’s background active by using `:focus-visible`.
- Render the external Substack destination as a regular anchor.

## Why

Previously, hover and active navigation items used the same background treatment, so the current page was not clearly indicated.

This introduces a Stripe Blog-inspired active-tab transition while preserving lightweight hover feedback and providing a persistent active-page state.

## Motion and accessibility

- The indicator transitions over 200ms using the existing in-out quart easing.
- Icon hover colors transition over 150ms.
- The active icon color is delayed until the indicator finishes moving.
- Hover and keyboard focus take priority during interaction.
- Existing duration tokens reduce the new motion to `0ms` when reduced motion is preferred.

## Validation

- `npm run lint`
  - Passed with one unrelated pre-existing warning in `app/components/home/hero-section.tsx`.
- `npm run typecheck`
- `npm run build:rr`
- `npm run build:info`
- Verified the production CSS contains the active-route, delayed-color, and transform/opacity selectors.